### PR TITLE
Added call started/ended message to the chat window.

### DIFF
--- a/friend.c
+++ b/friend.c
@@ -40,6 +40,21 @@ void friend_notify(FRIEND *f, uint8_t *str, uint16_t str_length, uint8_t *msg, u
     notify(title, len, msg, msg_length);
 }
 
+void friend_add_str_message(FRIEND *f, char_t *data, uint16_t length)
+{
+    MESSAGE *msg = malloc(sizeof(MESSAGE) + length);
+    msg->flags = 2;
+    msg->length = length;
+    uint8_t *p = msg->msg;
+    memcpy(p, data, length);
+
+    message_add(&messages_friend, msg, &f->msg);
+
+    if(sitem->data != f) {
+        f->notify = 1;
+    }
+}
+
 void friend_addmessage(FRIEND *f, void *data)
 {
     MESSAGE *msg = data;

--- a/friend.h
+++ b/friend.h
@@ -61,6 +61,7 @@ void friend_addmessage(FRIEND *f, void *data);
 
 void friend_notify(FRIEND *f, uint8_t *str, uint16_t str_length, uint8_t *msg, uint16_t msg_length);
 #define friend_notifystr(f, str, msg, mlen) friend_notify(f, (uint8_t*)str, sizeof(str) - 1, msg, mlen)
+void friend_add_str_message(FRIEND *f, char_t *data, uint16_t length);
 
 void friend_addid(uint8_t *id, char_t *msg, uint16_t msg_length);
 void friend_add(char_t *name, uint16_t length, char_t *msg, uint16_t msg_length);

--- a/tox.c
+++ b/tox.c
@@ -798,6 +798,7 @@ static void call_notify(FRIEND *f, uint8_t status)
 {
     STRING *str = &callstatus[status & 3];
     friend_notify(f, str->str, str->length, (uint8_t*)"", 0);
+    friend_add_str_message(f, str->str, str->length);
 }
 
 void tox_message(uint8_t msg, uint16_t param1, uint16_t param2, void *data)

--- a/ui_strings.h
+++ b/ui_strings.h
@@ -28,7 +28,7 @@ STRING filestatus[] = {
 STRING callstatus[] = {
     AFS("Call cancelled"),
     AFS("Call invited"),
-    AFS(".."),
+    AFS("Call ringing"),
     AFS("Call started")
 };
 


### PR DESCRIPTION
This pull request adds a log message to the chat window on each user action Tox currently supports (cancell, invite, ring, start).

Here is a more descriptive list:
- Added function `friend_add_str_message` to simplify addition of
  messages
- Added message to the chat window on call start/end.
- Updated `callstatus` strings to look more like automatically generated
  messages

Note that a similar functionality could be implemented for file transfers.
