### PR TITLE
Rephrased friend invite

### DIFF
--- a/ui_strings.h
+++ b/ui_strings.h
@@ -1,7 +1,7 @@
 #define AFS(x) { .str = (uint8_t*)x, .length = sizeof(x) - 1 }
 
 static STRING addstatus[] = {
-    AFS("Friend request sent. Your friend will appear online when he accepts the request."),
+    AFS("Friend request sent. Your friend will appear online after accepting it."),
     AFS("Attempting to resolve DNS name..."),
     AFS("Error: Invalid Tox ID"),
     AFS("Error: No Tox ID specified"),


### PR DESCRIPTION
Hello notsecure,

This is kind of like a follow-up to #134, resolving all the issues I believe were raised about making this statement "gender-neutral":
- The statement is now shorter than the original statement by several characters.
- The statement is grammatically correct.

Please consider merging this patch.

Kind Regards,
SylvieLorxu
