### PR TITLE
Set the default thread stack size

### DIFF
--- a/xlib/main.c
+++ b/xlib/main.c
@@ -329,7 +329,7 @@ void thread(void func(void*), void *args)
     pthread_t thread_temp;
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-    pthread_attr_setstacksize(&attr, 1 << 17);
+    pthread_attr_setstacksize(&attr, 1 << 18);
     pthread_create(&thread_temp, &attr, (void*(*)(void*))func, args);
     pthread_attr_destroy(&attr);
 }


### PR DESCRIPTION
POSIX does not specify the stack size of a thread created with
pthread_create(). tox needs a lot of stack, more than musl libc's
default stack size of 80KB, but less than glibc's 8MB. It seems that
128KB is enough.
