### PR TITLE
Moved Search Box and fixed swapping

### DIFF
--- a/list.c
+++ b/list.c
@@ -299,10 +299,7 @@ void list_draw(void *n, int x, int y, int width, int height)
     ITEM *i = item, *mi = NULL;
     FRIEND *f;
     j = 0;
-    k = y / ITEM_HEIGHT;
-    if(y < 0){
-        k -= 1;
-    }
+    k = 0;
     //TODO: only draw visible
     while(i != &item[itemcount]) {
         f = i->data;
@@ -316,7 +313,8 @@ void list_draw(void *n, int x, int y, int width, int height)
             } else {
                 drawitem(i, LIST_X, y);
             }
-            search_offset[j] = k - (y) / ITEM_HEIGHT;
+            search_offset[j] = k - j;
+            search_unset[k] = j - k;
             j++;
             y += ITEM_HEIGHT;
         }
@@ -484,9 +482,10 @@ _Bool list_mmove(void *n, int x, int y, int width, int height, int mx, int my, i
             } else {
                 d = (sitem_dy - ITEM_HEIGHT / 2) / ITEM_HEIGHT;
             }
-
-            ITEM *i = sitem + d - search_offset[sitem - item] + search_offset[d];
-            if(d != 0 && i >= item && i < &item[searchcount]) {
+            int unset = search_unset[sitem - item];
+            ITEM *i = sitem + d + unset + search_offset[(sitem - item) + unset + d];
+            debug("i : %li search_unset : %i item : %i\n", i - item, search_unset[i - item], searchcount);
+            if(d != 0 && i >= item && (i + search_unset[i - item]) < &item[searchcount]) {
                 nitem = i;
             }
         }

--- a/ui.c
+++ b/ui.c
@@ -636,10 +636,10 @@ void ui_scale(uint8_t scale)
 
     e_search = {
         .type = PANEL_EDIT,
-        .x = 5 * SCALE,
-        .y = LIST_BOTTOM - 12 * SCALE,
+        .x = 0,
+        .y = SEARCH_Y,
         .height = 12 * SCALE,
-        .width = SCALE * 27 * 4 - 5,
+        .width = LIST_RIGHT,
     };
 
     edit_name.panel = e_name;

--- a/ui.h
+++ b/ui.h
@@ -84,6 +84,7 @@ extern uint32_t status_color[];
 
 uint8_t SEARCH;
 int search_offset[1024];
+int search_unset[1024];
 char search_data[128];
 
 /* metrics
@@ -93,7 +94,7 @@ uint8_t SCALE;
 /* side */
 #define LIST_X (8 * SCALE)
 #define LIST_RIGHT (111 * SCALE)
-#define LIST_Y (31 * SCALE)
+#define LIST_Y (43 * SCALE)
 #define LIST_BOTTOM (-18 * SCALE)
 
 #define LIST_NAME_X (37 * SCALE)
@@ -129,6 +130,8 @@ uint8_t SCALE;
 #define NAME_OFFSET (7 * SCALE)
 
 #define MESSAGES_BOTTOM (-47 * SCALE)
+
+#define SEARCH_Y (31 * SCALE)
 
 /* main */
 //#define MAIN_X

--- a/ui_edits.h
+++ b/ui_edits.h
@@ -80,6 +80,8 @@ static void edit_search_onchange(void)
     uint16_t length = edit_search.length;
 
     if(!length) {
+        memset(search_offset, 0, sizeof(int) * 1024);
+        memset(search_unset, 0, sizeof(int) * 1024);
         SEARCH = 0;
     } else {
         SEARCH = 1;


### PR DESCRIPTION
Swapping works correctly now: One caveat, if you drop the item outside the searched list (But it is still within bounds for the normal list) it will swap those two items. Not sure how to prevent this without making a mess at the momment, but I will be looking into it still.
