### PR TITLE
check LC_MESSAGES before checking LANG

### DIFF
--- a/xlib/main.c
+++ b/xlib/main.c
@@ -775,7 +775,10 @@ static UTOX_SAVE* loadconfig(void)
 
 static int systemlang(void)
 {
-    char *str = getenv("LANG");
+    char *str = getenv("LC_MESSAGES");
+    if(!str) {
+        str = getenv("LANG");
+    }
     if(!str) {
         return LANG_EN;
     }


### PR DESCRIPTION
LC_MESSAGES is the standard way to set the language of the displayed messages if the user wants it to be different than the one set in LANG.
