### PR TITLE
Make library set system dependent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
+UNAME_S := $(shell uname -s)
+
 CFLAGS += $(shell pkg-config --cflags freetype2 x11 openal)
 CFLAGS += $(shell pkg-config --cflags dbus-1)
 CFLAGS += -g -pthread -std=gnu99
 LDFLAGS += $(shell pkg-config --libs freetype2 x11 openal)
 LDFLAGS += $(shell pkg-config --libs dbus-1)
-LDFLAGS += -lX11 -lXft -lXrender -ltoxcore -ltoxav -ltoxdns -lopenal -pthread -lresolv -ldl -lm -lfontconfig -lv4lconvert -lvpx -lXext
+LDFLAGS += -lX11 -lXft -lXrender -ltoxcore -ltoxav -ltoxdns -lopenal -pthread -lm -lfontconfig -lv4lconvert -lvpx -lXext
+
+ifeq ($(UNAME_S),Linux)
+	LDFLAGS += -lresolv -ldl
+endif
 
 DESTDIR?=	# empty
 PREFIX?=	/usr/local


### PR DESCRIPTION
For instance, FreeBSD doesn't need -lresolv, -ldl

(note: I haven't tested this on Linux, please do)
