### PR TITLE
Don't exit if no input methods can be found

### DIFF
--- a/xlib/event.c
+++ b/xlib/event.c
@@ -245,10 +245,13 @@ _Bool doevent(XEvent event)
         KeySym sym = XLookupKeysym(ev, 0);//XKeycodeToKeysym(display, ev->keycode, 0)
 
         wchar_t buffer[16];
-        Status status_return;
         int len;
 
-        len = XwcLookupString(xic, ev, buffer, sizeof(buffer), &sym, &status_return);
+        if (xic) {
+            len = XwcLookupString(xic, ev, buffer, sizeof(buffer), &sym, NULL);
+        } else {
+            len = XLookupString(ev, (char *)buffer, sizeof(buffer), &sym, NULL);
+        }
         if(edit_active()) {
             if(ev->state & 4) {
                 switch(sym) {

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -83,7 +83,7 @@ _Bool _redraw;
 
 uint16_t drawwidth, drawheight;
 
-XIC xic;
+XIC xic = NULL;
 
 XImage *screen_image;
 
@@ -844,7 +844,6 @@ int main(int argc, char *argv[])
     XSetLocaleModifiers("");
     if((xim = XOpenIM(display, 0, 0, 0)) == NULL) {
         printf("Cannot open input method\n");
-        return 1;
     }
 
     screen = DefaultScreen(display);
@@ -990,11 +989,13 @@ int main(int argc, char *argv[])
     /* make the window visible */
     XMapWindow(display, window);
 
-    if((xic = XCreateIC(xim, XNInputStyle, XIMPreeditNothing | XIMStatusNothing, XNClientWindow, window, XNFocusWindow, window, NULL)) == NULL) {
-        printf("Cannot open input method\n");
-        return 1;
+    if (xim) {
+        if((xic = XCreateIC(xim, XNInputStyle, XIMPreeditNothing | XIMStatusNothing, XNClientWindow, window, XNFocusWindow, window, NULL)) == NULL) {
+            printf("Cannot open input method\n");
+            XCloseIM(xim);
+        }
+        XSetICFocus(xic);
     }
-    XSetICFocus(xic);
 
     /* set the width/height of the drawing region */
     width = DEFAULT_WIDTH;
@@ -1081,6 +1082,9 @@ int main(int argc, char *argv[])
 
     XRenderFreePicture(display, renderpic);
     XRenderFreePicture(display, colorpic);
+
+    if (xic) XDestroyIC(xic);
+    if (xim) XCloseIM(xim);
 
     XDestroyWindow(display, window);
     XCloseDisplay(display);


### PR DESCRIPTION
Sorry again. This should hopefully fix up the problems with fba5e00391d2279572b71a472272375f2434b45a
