### PR TITLE
Don't draw textfields below a certain width

### DIFF
--- a/ui.c
+++ b/ui.c
@@ -806,7 +806,9 @@ static void panel_draw_sub(PANEL *p, int x, int y, int width, int height)
 
 
     if(p->type) {
-        drawfunc[p->type - 1](p, x, y, width, height);
+        if(p->type != PANEL_EDIT || width > 15 * SCALE) {
+            drawfunc[p->type - 1](p, x, y, width, height);
+        }
     } else {
         if(p->drawfunc) {
             p->drawfunc(x, y, width, height);


### PR DESCRIPTION
## Abstract

Normally, the wmhints limited the window to a minwidth and minheight. However, according to the ICCCM-conventions, it's not good practice relying on the wmhints to mask undefined behaviour.
## How to reproduce

The bug currently exists on all platforms and is reproducable by removing the size-hints on the window (comment out xlib/main.c:696 for XLib-testing).
Now, scale the window down arbitrarily and you'll sooner or later notice that the window is frozen and won't redraw.
## Explanation

Somehow, there's an issue drawing PANEL_EDITs (textfields) smaller than a certain width (somehow the width of the scrollbar).
This patch prevents the textfield from being drawn when it reaches a certain margin.

Given this margin is never reached in floating state, and only used to fix freezes in tiling-wm's and other weird circumstances you can read in the other issue-reports, this won't happen in most cases.
However, it sure will fix freezes that have already been reported numerous times.
