### PR TITLE
Deal with FT_RENDER_MODE_MONO

### DIFF
--- a/xlib/freetype.c
+++ b/xlib/freetype.c
@@ -188,18 +188,18 @@ GLYPH* font_getglyph(FONT *f, uint32_t ch)
     g->xadvance = (p->advance.x + (1 << 5)) >> 6;
 
     if(p->bitmap.pixel_mode == FT_PIXEL_MODE_MONO) {
-        unsigned int r, x, pitch = p->bitmap.pitch*8;
-        uint8_t *mybuf = calloc(pitch*p->bitmap.rows, 1);
-        uint8_t *sline = p->bitmap.buffer, *dline = mybuf;
+        unsigned int r, x;
+        uint8_t *mybuf = malloc(p->bitmap.width*g->height);
+        uint8_t *sline = p->bitmap.buffer, *dest = mybuf;
 
-        for(r = 0; r < p->bitmap.rows; r++, sline += p->bitmap.pitch, dline += pitch) {
-            for(x = 0; x < p->bitmap.width; x++) {
-                dline[x] = (sline[(x >> 3)] & (0x80 >> (x & 7))) * 0xff;
+        g->width = p->bitmap.width;
+        for(r = 0; r < g->height; r++, sline += p->bitmap.pitch) {
+            for(x = 0; x < g->width; x++, dest++) {
+                *dest = (sline[(x >> 3)] & (0x80 >> (x & 7))) * 0xff;
             }
         }
         free(p->bitmap.buffer);
         p->bitmap.buffer = mybuf;
-        g->width = p->bitmap.pitch = pitch;
         no_subpixel = 1;
     }
 


### PR DESCRIPTION
Seems to be needed for bitmap fonts and fonts with embedded bitmaps.
This should now hopefully solve #206.
