### PR TITLE
Remove Xft library from dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@
 
 Dependencies on Debian Jessie:
 ```bash
-sudo apt-get install libv4l-dev libopenal-dev libfreetype6-dev libdbus-1-dev libxrender-dev libfontconfig1-dev libxext-dev libxft-dev
+sudo apt-get install libv4l-dev libopenal-dev libfreetype6-dev libdbus-1-dev libxrender-dev libfontconfig1-dev libxext-dev
 ```
 
 Compile:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LDFLAGS += $(shell pkg-config --libs dbus-1)
 endif
 LDFLAGS += $(shell pkg-config --libs libtoxcore)
 LDFLAGS += $(shell pkg-config --libs libtoxav)
-LDFLAGS += -lX11 -lXft -lXrender -lopenal -pthread -lm -lfontconfig -lv4lconvert -lvpx -lXext
+LDFLAGS += -lX11 -lXrender -lopenal -pthread -lm -lfontconfig -lv4lconvert -lvpx -lXext
 
 ifeq ($(UNAME_S),Linux)
 	LDFLAGS += -lresolv -ldl


### PR DESCRIPTION
It seems to be unused after 3bcc168a0c0c655d5eeb30f8eb94ed97238e0b93.
