### PR TITLE
OS X build instructions need a little refresher

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,7 +48,11 @@ or if you built toxcore statically:
 ## OS X
 You need XQuartz on 10.8+, no video yet.
 
-> cc -o uTox.o *.c -I/opt/X11/include -L/opt/X11/lib -lX11 -lXrender -lXext -ltoxcore -ltoxav -ltoxdns -framework OpenAL -pthread -lresolv -ldl -lm -lfontconfig -lfreetype -lvpx -I/opt/X11/include/freetype2
+> cc -o uTox.o *.c png/png.c -I/opt/X11/include -L/opt/X11/lib -lX11 -lXrender -lXext -ltoxcore -ltoxav -ltoxdns -framework OpenAL -pthread -lresolv -ldl -lm -lfontconfig -lfreetype -lvpx -I/opt/X11/include/freetype2
+
+If you are relying on Homebrew to provide libraries and headers, you can use the following line instead to save you the trouble:
+
+> cc -o uTox.o *.c png/png.c -L/usr/local/lib -I/usr/local/include -I/opt/X11/include -L/opt/X11/lib -lX11 -lXrender -lXext -ltoxcore -ltoxav -ltoxdns -framework OpenAL -pthread -lresolv -ldl -lm -lfontconfig -lfreetype -lvpx -I/opt/X11/include/freetype2
 
 <a name="windows" />
 ## Windows


### PR DESCRIPTION
When building uTox on OS X, we need to specify lodepng within the png directory, or we get the following:

```
 cc -o uTox.o *.c -L/usr/local/lib -I/usr/local/include -I/opt/X11/include -L/opt/X11/lib -lX11 -lXrender -lXext -ltoxcore -ltoxav -ltoxdns -framework OpenAL -pthread -lresolv -ldl -lm -lfontconfig -lfreetype -lvpx -I/opt/X11/include/freetype2
Undefined symbols for architecture x86_64:
  "_lodepng_decode32", referenced from:
      _png_to_image in main-4ef908.o
  "_lodepng_encode_memory", referenced from:
      _doevent in main-4ef908.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Also, I added in an extra line for those using homebrew to provide libtoxcore.
