### PR TITLE
German: Keep "Tox ID" and "..." consistent and add missing strings.

### DIFF
--- a/ui_strings.h
+++ b/ui_strings.h
@@ -96,7 +96,7 @@ STRING strings[][64] = {
     //12
     STR("Neue Datenübertragung"),
     STR("Datenübertragung gestartet"),
-    STR(".."),
+    STR("..."),
     STR("Datenübertragung pausiert"),
     STR("Datenübertragung fehlerhaft"),
     STR("Datenübertragung abgebrochen"),


### PR DESCRIPTION
Thanks to @zetok & @albel727 for reporting the issues.
