### PR TITLE
Saving name and status changes after switching to friends view

### DIFF
--- a/ui_buttons.h
+++ b/ui_buttons.h
@@ -240,6 +240,9 @@ static void button_sendfile_onpress(void)
 
 static void button_sendfile_updatecolor(BUTTON *b)
 {
+    edit_setfocus(&edit_name);      // to reflect changes in name if a friend view is selected
+    edit_setfocus(&edit_status);
+
     FRIEND *f = sitem->data;
     if(f->online) {
         b->c1 = C_GREEN;


### PR DESCRIPTION
The changes made to the user name or user status are not always reflected. In particular, if after making a change we select a friend from the list.

I added a call to the updaters of name and status so that the changes are taken into account.
