### PR TITLE
Fix utox.desktop version string

### DIFF
--- a/utox.desktop
+++ b/utox.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=0.18
+Version=1.0
 Type=Application
 Name=uTox
 Comment=A lightweight Tox client


### PR DESCRIPTION
The version string in the .desktop file is not the version of the software, but the version of the "Desktop Entry Specification" that the .desktop file conforms to. With this being the case, 1.0 is the correct value.

More info: http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-1.0.html#recognized-keys
