### PR TITLE
Added tooltip feature for buttons. notsecure/uTox#277

### DIFF
--- a/android/main.c
+++ b/android/main.c
@@ -443,6 +443,10 @@ void redraw(void)
 {
     _redraw = 1;
 }
+void force_redraw(void)
+{
+    redraw();
+}
 
 static void android_main(void) /* main thread */
 {

--- a/button.c
+++ b/button.c
@@ -78,6 +78,10 @@ _Bool button_mmove(BUTTON *b, int UNUSED(x), int UNUSED(y), int width, int heigh
     _Bool mouseover = inrect(mx, my, real_x, 0, real_w, height);
     if(mouseover) {
         cursor = CURSOR_HAND;
+        if(maybe_i18nal_string_is_valid(&b->tooltip_text)) {
+            tooltip_new(&b->tooltip_text);
+        }
+
     }
     if(mouseover != b->mouseover) {
         b->mouseover = mouseover;

--- a/button.h
+++ b/button.h
@@ -11,6 +11,7 @@ struct button {
     uint32_t c1, c2, c3;
 
     MAYBE_I18NAL_STRING button_text;
+    MAYBE_I18NAL_STRING tooltip_text;
 
     _Bool mouseover, mousedown, disabled, nodraw;
 

--- a/main.h
+++ b/main.h
@@ -90,6 +90,7 @@ typedef struct edit_change EDIT_CHANGE;
 #include "button.h"
 #include "dropdown.h"
 #include "contextmenu.h"
+#include "tooltip.h"
 
 #include "text.h"
 #include "util.h"
@@ -212,6 +213,7 @@ void drawimage(UTOX_NATIVE_IMAGE, int x, int y, int width, int height, int maxwi
 UTOX_NATIVE_IMAGE png_to_image(UTOX_PNG_IMAGE, size_t png_size, uint16_t *w, uint16_t *h);
 void showkeyboard(_Bool show);
 void redraw(void);
+void force_redraw(void); // TODO: as parameter for redraw()?
 
 int datapath_old(uint8_t *dest);
 int datapath(uint8_t *dest);

--- a/tooltip.c
+++ b/tooltip.c
@@ -66,6 +66,7 @@ _Bool tooltip_mdown(void)
     TOOLTIP *b = &tooltip;
 
     b->can_show = 0;
+    b->mouse_down = 1;
 
     if(!b->visible) {
         return 0;
@@ -73,6 +74,14 @@ _Bool tooltip_mdown(void)
 
     b->visible = 0;
     return 1;
+}
+_Bool tooltip_mup(void)
+{
+    TOOLTIP *b = &tooltip;
+
+    b->can_show = 0;
+    b->mouse_down = 0;
+    return 0;
 }
 
 void tooltip_show(void)
@@ -101,7 +110,7 @@ void tooltip_new(MAYBE_I18NAL_STRING* text)
     b->can_show = 1;
     b->tt_text = text;
 
-    if(b->timer_running || b->visible) {
+    if(b->timer_running || b->visible || b->mouse_down) {
         return;
     }
     thread(mouse_pos_check,NULL);
@@ -116,10 +125,9 @@ void mouse_pos_check(void *UNUSED(args))
         if(mouse.x - old_x == 0 && mouse.y - old_y == 0) {
             if(tick >= 10) {
                 // 1 second of not moving, show tooltip
-                if(b->can_show) {
+                if(b->can_show && !b->mouse_down) {
                     tooltip_show();
                 }
-                tick = 0;
                 break;
             } else {
                 tick++;
@@ -132,5 +140,7 @@ void mouse_pos_check(void *UNUSED(args))
         }
         yieldcpu(100);
     }
+    tick = 0;
+    b->visible = 1;
     b->timer_running = 0;
 }

--- a/tooltip.c
+++ b/tooltip.c
@@ -1,0 +1,136 @@
+#include "main.h"
+
+static TOOLTIP tooltip;
+
+#define TOOLTIP_WIDTH (SCALE * 12)
+#define TOOLTIP_HEIGHT (SCALE * 12)
+#define TOOLTIP_YOFFSET 12
+
+static void calculate_pos_and_width(TOOLTIP *b, int *x, int *w) {
+    *x = b->x;
+    *w = b->width;
+
+    // Increase width if needed, so that tooltip text fits.
+    if(maybe_i18nal_string_is_valid(b->tt_text)) {
+        STRING* s = maybe_i18nal_string_get(b->tt_text);
+        int needed_w = textwidth(s->str, s->length) + 4 * SCALE;
+        if(*w < needed_w) {
+            *w = needed_w;
+        }
+    }
+
+    // Push away from the right border to fit.
+    if(*x + *w >= utox_window_width) {
+        *x -= *w;
+    }
+}
+
+void tooltip_draw(void)
+{
+    TOOLTIP *b = &tooltip;
+    if(!b->visible) {
+        return;
+    }
+
+    // Ensure that font is set before calculating position and width.
+    setfont(FONT_TEXT);
+    setcolor(COLOR_TEXT);
+
+    int x, w;
+    calculate_pos_and_width(b, &x, &w);
+
+    drawrectw(x, b->y, w, b->height, C_YELLOW_LIGHT);
+
+    STRING* s = maybe_i18nal_string_get(b->tt_text);
+    drawtext(x + SCALE * 2, b->y + SCALE * 2, s->str, s->length);
+
+    framerect(x, b->y, x + w, b->y + b->height, C_YELLOW);
+}
+
+_Bool tooltip_mmove(void)
+{
+    TOOLTIP *b = &tooltip;
+
+    b->can_show = 0;
+
+    if(!b->visible) {
+        return 0;
+    }
+
+    b->visible = 0;
+    return 1;
+}
+
+_Bool tooltip_mdown(void)
+{
+    TOOLTIP *b = &tooltip;
+
+    b->can_show = 0;
+
+    if(!b->visible) {
+        return 0;
+    }
+
+    b->visible = 0;
+    return 1;
+}
+
+void tooltip_show(void)
+{
+    TOOLTIP *b = &tooltip;
+
+    b->y = mouse.y + TOOLTIP_YOFFSET;
+    b->height = TOOLTIP_HEIGHT;
+    if(b->y + b->height >= utox_window_height) {
+        b->y -= (b->height + TOOLTIP_YOFFSET);
+    }
+    b->x = mouse.x;
+    b->width = TOOLTIP_WIDTH;
+
+    b->visible = 1;
+
+    // Only needed for Xlib to unblock XNextEvent
+    force_redraw();
+}
+
+// This is being called everytime the mouse is moving above a button
+void tooltip_new(MAYBE_I18NAL_STRING* text)
+{
+    TOOLTIP *b = &tooltip;
+
+    b->can_show = 1;
+    b->tt_text = text;
+
+    if(b->timer_running || b->visible) {
+        return;
+    }
+    thread(mouse_pos_check,NULL);
+}
+
+void mouse_pos_check(void *UNUSED(args))
+{
+    TOOLTIP *b = &tooltip;
+    int old_x = 0, old_y = 0, tick = 0;
+    b->timer_running = 1;
+    while(1) {
+        if(mouse.x - old_x == 0 && mouse.y - old_y == 0) {
+            if(tick >= 10) {
+                // 1 second of not moving, show tooltip
+                if(b->can_show) {
+                    tooltip_show();
+                }
+                tick = 0;
+                break;
+            } else {
+                tick++;
+            }
+            //debug("Mouse stopped. X: %d, Y: %d, OX: %d, OY: %d\n",mouse.x,mouse.y,old_x,old_y);
+        } else {
+            old_x = mouse.x;
+            old_y = mouse.y;
+            tick = 0;
+        }
+        yieldcpu(100);
+    }
+    b->timer_running = 0;
+}

--- a/tooltip.h
+++ b/tooltip.h
@@ -1,0 +1,18 @@
+typedef struct tooltip {
+    int x, y, width, height;
+    _Bool visible;
+
+    _Bool timer_running;
+    _Bool can_show;
+
+    MAYBE_I18NAL_STRING* tt_text;
+} TOOLTIP;
+
+void tooltip_draw(void);
+_Bool tooltip_mmove(void);
+_Bool tooltip_mdown(void);
+
+void tooltip_show(void);
+void tooltip_new(MAYBE_I18NAL_STRING* text);
+
+void mouse_pos_check(void *UNUSED(args));

--- a/tooltip.h
+++ b/tooltip.h
@@ -4,6 +4,7 @@ typedef struct tooltip {
 
     _Bool timer_running;
     _Bool can_show;
+    _Bool mouse_down;
 
     MAYBE_I18NAL_STRING* tt_text;
 } TOOLTIP;
@@ -11,6 +12,7 @@ typedef struct tooltip {
 void tooltip_draw(void);
 _Bool tooltip_mmove(void);
 _Bool tooltip_mdown(void);
+_Bool tooltip_mup(void);
 
 void tooltip_show(void);
 void tooltip_new(MAYBE_I18NAL_STRING* text);

--- a/ui.c
+++ b/ui.c
@@ -937,6 +937,7 @@ void panel_draw(PANEL *p, int x, int y, int width, int height)
 
     dropdown_drawactive();
     contextmenu_draw();
+    tooltip_draw();
 
     enddraw(x, y, width, height);
 }
@@ -968,6 +969,10 @@ _Bool panel_mmove(PANEL *p, int x, int y, int width, int height, int mx, int my,
     }
 
     _Bool draw = p->type ? mmovefunc[p->type - 1](p, x, y, width, height, mx, mmy, dx, dy) : 0;
+    // Has to be called before children mmove
+    if(p == &panel_main) {
+        draw |= tooltip_mmove();
+    }
     PANEL **pp = p->child, *subp;
     if(pp) {
         while((subp = *pp++)) {
@@ -1009,7 +1014,7 @@ static _Bool panel_mdown_sub(PANEL *p)
 
 void panel_mdown(PANEL *p)
 {
-    if(contextmenu_mdown()) {
+    if(contextmenu_mdown() || tooltip_mdown()) {
         redraw();
         return;
     }

--- a/ui.c
+++ b/ui.c
@@ -1119,6 +1119,7 @@ _Bool panel_mup(PANEL *p)
 
     if(p == &panel_main) {
         draw |= contextmenu_mup();
+        tooltip_mup();
         if(draw) {
             redraw();
         }

--- a/win32/main.c
+++ b/win32/main.c
@@ -791,6 +791,9 @@ void redraw(void)
 {
     panel_draw(&panel_main, 0, 0, utox_window_width, utox_window_height);
 }
+void force_redraw(void) {
+    redraw();
+}
 
 static int grabx, graby, grabpx, grabpy;
 static _Bool grabbing;

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -74,6 +74,7 @@ uint32_t scolor;
 Atom XA_CLIPBOARD, XA_UTF8_STRING, targets, XA_INCR;
 Atom XdndAware, XdndEnter, XdndLeave, XdndPosition, XdndStatus, XdndDrop, XdndSelection, XdndDATA, XdndActionCopy;
 Atom XA_URI_LIST, XA_PNG_IMG;
+Atom XRedraw;
 
 Pixmap drawbuf;
 Picture renderpic;
@@ -729,6 +730,23 @@ void redraw(void)
 {
     _redraw = 1;
 }
+void force_redraw(void) {
+    XEvent ev = {
+        .xclient = {
+            .type = ClientMessage,
+            .display = display,
+            .window = window,
+            .message_type = XRedraw,
+            .format = 8,
+            .data = {
+                .s = {0,0}
+            }
+        }
+    };
+    _redraw = 1;
+    XSendEvent(display, window, 0, 0, &ev);
+    XFlush(display);
+}
 
 #include "event.c"
 
@@ -827,6 +845,8 @@ int main(int argc, char *argv[])
 
     XA_URI_LIST = XInternAtom(display, "text/uri-list", False);
     XA_PNG_IMG = XInternAtom(display, "image/png", False);
+
+    XRedraw = XInternAtom(display, "XRedraw", False);
 
     /* create the draw buffer */
     drawbuf = XCreatePixmap(display, window, DEFAULT_WIDTH, DEFAULT_HEIGHT, depth);


### PR DESCRIPTION
When moving over a button, which has a tooltip set, a thread will start and check the mouse position. Once the mouse stops moving and is still over a button it will display the buttons tooltip next to the cursor.

To add a tooltip to a button, you can define a i18nal string in "ui_button.h" with tooltip_text as you would define button_text.
Example:
```c
button_chat2 = {
    .bm = BM_CB2,
    .c1 = C_GREEN,
    .c2 = C_GREEN_LIGHT,
    .c3 = C_GREEN_LIGHT,
    .tooltip_text = { .i18nal = STR_YES },
},
```
The thread will continue running until the mouse stops for atleast 1 second. It is then checked whether a tooltip is to be shown or not and the thread will terminate.

I am not experienced with C and threading, so if you see anything that might break during certain scenarios, leak memory or behave strangely, please point them out.

In that regard, here are some notes I've been wondering about:
- Are locks neccessary for the thread regarding the struct members "timer_running" and "can_show"? Is it possible for another thread to start in the time "timer_running" is set and another thread is being initialized?

- I think the the thread can be terminated the moment the mouse stops moving when checking for "can_show" instead of waiting another second.

- Creation of another redraw function. And the only reason was the blocking of XNextEvent. My idea was to add a parameter for the redraw function for this case, but since it would need alot of refactoring I rather wait for some feedback on this.

- I have no idea how the android client looks like and how this will even work UI wise...