### PR TITLE
[win32] tray icon now returns active tox name

### DIFF
--- a/main.h
+++ b/main.h
@@ -222,6 +222,7 @@ void drawimage(UTOX_NATIVE_IMAGE, int x, int y, int width, int height, int maxwi
 UTOX_NATIVE_IMAGE png_to_image(UTOX_PNG_IMAGE, size_t png_size, uint16_t *w, uint16_t *h);
 void showkeyboard(_Bool show);
 void redraw(void);
+void readraw_tray(void);
 
 int datapath_old(uint8_t *dest);
 int datapath(uint8_t *dest);

--- a/ui_edits.h
+++ b/ui_edits.h
@@ -13,6 +13,7 @@ static void edit_name_onenter(void)
 
     memcpy(self.name, data, length);
     self.name_length = length;
+    redraw_tray();
 
     tox_postmessage(TOX_SETNAME, length, 0, self.name);//!
 }

--- a/win32/main.c
+++ b/win32/main.c
@@ -805,6 +805,17 @@ void redraw(void)
 {
     panel_draw(&panel_main, 0, 0, utox_window_width, utox_window_height);
 }
+void redraw_tray(void)
+{
+    NOTIFYICONDATAW nid = {
+        .uFlags = NIF_TIP,
+        .hWnd = hwnd,
+        .cbSize = sizeof(nid),
+    };
+
+    utf8tonative(self.name, nid.szTip, self.name_length > sizeof(nid.szTip) / sizeof(*nid.szTip) -1 ? sizeof(nid.szTip) / sizeof(*nid.szTip) -1 : self.name_length);
+    Shell_NotifyIconW(NIM_MODIFY, &nid);
+}
 
 static int grabx, graby, grabpx, grabpy;
 static _Bool grabbing;
@@ -1081,6 +1092,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR cmd, int n
     tme.hwndTrack = hwnd;
 
     nid.hWnd = hwnd;
+    strcpy(nid.szTip, self.name);
     Shell_NotifyIcon(NIM_ADD, &nid);
 
     SetBkMode(hdc, TRANSPARENT);


### PR DESCRIPTION
The tooltip of the tray icon now returns the active username.

TODO:
- [ ] change when disconnected
- [ ] also display current status
- [x] show mood message
