### PR TITLE
GNU/Linux typo fix

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,13 +1,13 @@
 # Install
 
-- [Unix like](#unix)
+- [GNU/Linux](#unix)
 - [OS X](#osx)
 - [Windows](#windows)
 - [Android](#android)
 - [Binaries](#binaries)
 
 <a name="unix" />
-## Linux / Unix-like
+## GNU/Linux (Unix-like)
 
 Dependencies on Debian Jessie:
 ```bash
@@ -92,7 +92,7 @@ jarsigner -sigalg SHA1withRSA -digestalg SHA1 -keystore ./tmp/debug.keystore -st
 
 **Caution**: These are automatically compiled with every push and possibly unstable.
 
-- Linux
+- GNU/Linux
   - [amd64](https://jenkins.libtoxcore.so/view/Clients/job/uTox_linux_amd64/) [[.tar.xz]](https://jenkins.libtoxcore.so/view/Clients/job/uTox_linux_amd64/lastSuccessfulBuild/artifact/utox/utox_linux_amd64.tar.xz)
   - [i686](https://jenkins.libtoxcore.so/view/Clients/job/uTox_linux_i686/) [[.tar.xz]](https://jenkins.libtoxcore.so/view/Clients/job/uTox_linux_i686/lastSuccessfulBuild/artifact/utox/utox_linux_i686.tar.xz)
 - Windows

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Install
 
-- [GNU/Linux](#unix)
+- [GNU/Linux (Unix-like)](#unix)
 - [OS X](#osx)
 - [Windows](#windows)
 - [Android](#android)

--- a/tools/cross-compile-windows.sh
+++ b/tools/cross-compile-windows.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script to cross compile utox for win64 from a linux host with ming32
+# Script to cross compile utox for win64 from a GNU/Linux host with ming32
 #
 # Expects build dir to be git root with filter_audio and toxcore libs in ../
 


### PR DESCRIPTION
What you're referring to as Linux, is in fact, GNU/Linux, or as I've recently taken to calling it, GNU plus Linux. Linux is not an operating system unto itself, but rather another free component of a fully functioning GNU system made useful by the GNU Coreutils, shell utilities and vital system components comprising a full OS as defined by POSIX.

Many computer users run a modified version of the GNU system every day, without realizing it. Through a peculiar turn of events, the version of GNU which is widely used today is often called "Linux", and many of its users are not aware that it is basically the GNU system, developed by the GNU Project.