### PR TITLE
Adding Archlinux dependency information

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,10 +9,17 @@
 <a name="unix" />
 ## Linux / Unix-like
 
-Dependencies on Debian Jessie:
-```bash
-sudo apt-get install libv4l-dev libopenal-dev libfreetype6-dev libdbus-1-dev libxrender-dev libfontconfig1-dev libxext-dev
-```
+Dependencies:
+
+- Debian Jessie:
+  ```bash
+  sudo apt-get install libv4l-dev libopenal-dev libfreetype6-dev libdbus-1-dev libxrender-dev libfontconfig1-dev libxext-dev
+  ```
+
+- Archlinux:
+  ```bash
+  sudo pacman -S dbus-c++ fontconfig freetype2 libdbus libvpx libxext libxrender openal v4l-utils
+  ```
 
 Compile:
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,10 +17,13 @@ Dependencies:
   ```
 
 - Archlinux:
+
   ```bash
   sudo pacman -S dbus-c++ fontconfig freetype2 libdbus libvpx libxext libxrender openal v4l-utils
   ```
-  Please note that [`tox-git`](https://aur.archlinux.org/packages/tox-git/) package from AUR is also required.
+    1. Note: `dbus-c++` is an optional dependency.
+
+    2. Please note that [`tox-git`](https://aur.archlinux.org/packages/tox-git/) package from AUR is also required (unless you have already built `toxcore` from source).
 
 Compile:
 ```bash

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,6 +20,7 @@ Dependencies:
   ```bash
   sudo pacman -S dbus-c++ fontconfig freetype2 libdbus libvpx libxext libxrender openal v4l-utils
   ```
+  Please note that [`tox-git`](https://aur.archlinux.org/packages/tox-git/) package from AUR is also required.
 
 Compile:
 ```bash


### PR DESCRIPTION
This list is mainly based on [`utox-git`'s `PKGBUILD`](https://aur.archlinux.org/packages/ut/utox-git/PKGBUILD) by Madotsuki.