### PR TITLE
Added transparent avatars

### DIFF
--- a/android/main.c
+++ b/android/main.c
@@ -60,6 +60,22 @@ void postmessage(uint32_t msg, uint16_t param1, uint16_t param2, void *data)
     write(pipefd[1], &piping, sizeof(PIPING));
 }
 
+void image_set_filter(UTOX_NATIVE_IMAGE *image, uint8_t filter)
+{
+}
+
+void image_set_scale(UTOX_NATIVE_IMAGE *image, double scale)
+{
+}
+
+void draw_image(const UTOX_NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32_t height, uint32_t imgx, uint32_t imgy)
+{
+}
+
+
+/* this function is no longer used, but it might contain handy information for creating the newer image draw functions
+   on android. Currently drawing images is unsupported.
+
 void drawimage(UTOX_NATIVE_IMAGE data, int x, int y, int width, int height, int maxwidth, _Bool zoom, double position)
 {
     GLuint texture = data;
@@ -81,10 +97,7 @@ void drawimage(UTOX_NATIVE_IMAGE data, int x, int y, int width, int height, int 
 
     glUniform3fv(k2, 1, one);
 }
-
-void drawavatarimage(UTOX_NATIVE_IMAGE data, int x, int y, int width, int height, int targetwidth, int targetheight)
-{
-}
+*/
 
 void thread(void func(void*), void *args)
 {

--- a/avatar.c
+++ b/avatar.c
@@ -129,11 +129,14 @@ int set_avatar(AVATAR *avatar, const uint8_t *data, uint32_t size, _Bool create_
     }
 
     uint16_t w, h;
-    UTOX_NATIVE_IMAGE image = png_to_image((UTOX_PNG_IMAGE)data, size, &w, &h);
+    UTOX_NATIVE_IMAGE *image = png_to_image((UTOX_PNG_IMAGE)data, size, &w, &h, 1);
     if(!UTOX_NATIVE_IMAGE_IS_VALID(image)) {
         debug("warning: avatar is invalid\n");
         return 0;
     } else {
+
+        avatar_free_image(avatar);
+
         avatar->image = image;
         avatar->width = w;
         avatar->height = h;
@@ -148,6 +151,15 @@ int set_avatar(AVATAR *avatar, const uint8_t *data, uint32_t size, _Bool create_
 void unset_avatar(AVATAR *avatar)
 {
     avatar->format = TOX_AVATAR_FORMAT_NONE;
+    avatar_free_image(avatar);
+}
+
+void avatar_free_image(AVATAR *avatar)
+{
+    if (avatar->image) {
+        image_free(avatar->image);
+        avatar->image = NULL;
+    }
 }
 
 /* sets self avatar, see self_set_and_save_avatar */

--- a/avatar.c
+++ b/avatar.c
@@ -22,6 +22,16 @@ int get_avatar_hash_location(char_t *dest, const char_t *id)
     return p - dest;
 }
 
+/* frees the image of an avatar, does nothing if image is NULL */
+void avatar_free_image(AVATAR *avatar)
+{
+    if (avatar->image) {
+        image_free(avatar->image);
+        avatar->image = NULL;
+    }
+}
+
+
 int load_avatar(const char_t *id, uint8_t *dest, uint32_t *size_out)
 {
     char_t path[512];
@@ -152,14 +162,6 @@ void unset_avatar(AVATAR *avatar)
 {
     avatar->format = TOX_AVATAR_FORMAT_NONE;
     avatar_free_image(avatar);
-}
-
-void avatar_free_image(AVATAR *avatar)
-{
-    if (avatar->image) {
-        image_free(avatar->image);
-        avatar->image = NULL;
-    }
 }
 
 /* sets self avatar, see self_set_and_save_avatar */

--- a/avatar.h
+++ b/avatar.h
@@ -5,7 +5,7 @@
 typedef struct avatar {
     uint8_t format; /* one of TOX_AVATAR_FORMAT */
     uint8_t hash[TOX_HASH_LENGTH]; /* tox_hash for the png data of this avatar */
-    UTOX_NATIVE_IMAGE image; /* converted avatar image to draw */
+    UTOX_NATIVE_IMAGE *image; /* converted avatar image to draw */
     uint16_t width, height; /* width and height of image (in pixels) */
 }AVATAR;
 
@@ -71,8 +71,12 @@ int delete_avatar_hash(const char_t *id);
  */
 int set_avatar(AVATAR *avatar, const uint8_t *data, uint32_t size, _Bool create_hash);
 
-/* unsets an avatar by setting its format to TOX_AVATAR_FORMAT_NONE */
+/* unsets an avatar by setting its format to TOX_AVATAR_FORMAT_NONE and
+ * freeing its image */
 void unset_avatar(AVATAR *avatar);
+
+/* frees the image of an avatar, does nothing if image is NULL */
+void avatar_free_image(AVATAR *avatar);
 
 /* sets own avatar based on given png data and saves it to disk if successful
  *  data is png data to set avatar to

--- a/avatar.h
+++ b/avatar.h
@@ -75,9 +75,6 @@ int set_avatar(AVATAR *avatar, const uint8_t *data, uint32_t size, _Bool create_
  * freeing its image */
 void unset_avatar(AVATAR *avatar);
 
-/* frees the image of an avatar, does nothing if image is NULL */
-void avatar_free_image(AVATAR *avatar);
-
 /* sets own avatar based on given png data and saves it to disk if successful
  *  data is png data to set avatar to
  *  size is size of data

--- a/friend.c
+++ b/friend.c
@@ -28,7 +28,7 @@ void friend_setname(FRIEND *f, char_t *name, STRING_IDX length)
     f->name[f->name_length] = 0;
 }
 
-void friend_sendimage(FRIEND *f, UTOX_NATIVE_IMAGE native_image, uint16_t width, uint16_t height, UTOX_PNG_IMAGE png_image, size_t png_size)
+void friend_sendimage(FRIEND *f, UTOX_NATIVE_IMAGE *native_image, uint16_t width, uint16_t height, UTOX_PNG_IMAGE png_image, size_t png_size)
 {
     MSG_IMG *msg = malloc(sizeof(MSG_IMG));
     msg->author = 1;
@@ -50,7 +50,7 @@ void friend_sendimage(FRIEND *f, UTOX_NATIVE_IMAGE native_image, uint16_t width,
 void friend_recvimage(FRIEND *f, UTOX_PNG_IMAGE png_image, size_t png_size)
 {
     uint16_t width, height;
-    UTOX_NATIVE_IMAGE native_image = png_to_image(png_image, png_size, &width, &height);
+    UTOX_NATIVE_IMAGE *native_image = png_to_image(png_image, png_size, &width, &height, 0);
     if(!UTOX_NATIVE_IMAGE_IS_VALID(native_image)) {
         return;
     }

--- a/friend.h
+++ b/friend.h
@@ -48,7 +48,7 @@ typedef struct groupchat {
 
 void friend_setname(FRIEND *f, char_t *name, STRING_IDX length);
 void friend_addmessage(FRIEND *f, void *data);
-void friend_sendimage(FRIEND *f, UTOX_NATIVE_IMAGE, uint16_t width, uint16_t height, UTOX_PNG_IMAGE, size_t png_size);
+void friend_sendimage(FRIEND *f, UTOX_NATIVE_IMAGE *, uint16_t width, uint16_t height, UTOX_PNG_IMAGE, size_t png_size);
 void friend_recvimage(FRIEND *f, UTOX_PNG_IMAGE, size_t png_size);
 
 void friend_notify(FRIEND *f, char_t *str, STRING_IDX str_length, char_t *msg, STRING_IDX msg_length);

--- a/list.c
+++ b/list.c
@@ -51,7 +51,7 @@ static void drawitem(ITEM *i, int UNUSED(x), int y)
 
         // draw avatar or default image
         if (friend_has_avatar(f)) {
-            drawavatarimage(f->avatar.image, LIST_AVATAR_X, y + LIST_AVATAR_Y, f->avatar.width, f->avatar.height, BM_CONTACT_WIDTH, BM_CONTACT_WIDTH);
+            draw_avatar_image(f->avatar.image, LIST_AVATAR_X, y + LIST_AVATAR_Y, f->avatar.width, f->avatar.height, BM_CONTACT_WIDTH, BM_CONTACT_WIDTH);
         } else {
             drawalpha(BM_CONTACT, LIST_AVATAR_X, y + LIST_AVATAR_Y, BM_CONTACT_WIDTH, BM_CONTACT_WIDTH, (sitem == i) ? LIST_MAIN : WHITE);
         }

--- a/main.h
+++ b/main.h
@@ -234,7 +234,9 @@ void image_set_filter(UTOX_NATIVE_IMAGE *image, uint8_t filter);
 void image_set_scale(UTOX_NATIVE_IMAGE *image, double scale);
 
 /* draws an utox image with or without alpha channel into the rect of (x,y,width,height) on the screen,
- * starting at position (imgx,imgy) of the image */
+ * starting at position (imgx,imgy) of the image
+ * WARNING: Windows can fail to show the image at all if the rect (imgx,imgy,width,height) contains even 1 pixel outside of
+ * the image's size AFTER SCALING, so be careful (We might want to improve this so this function is safer to use in the future) */
 void draw_image(const UTOX_NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32_t height, uint32_t imgx, uint32_t imgy);
 
 /* converts a png to a UTOX_NATIVE_IMAGE, returns a pointer to it, keeping alpha channel only if keep_alpha is 1 */

--- a/main.h
+++ b/main.h
@@ -219,17 +219,30 @@ void loadalpha(int bm, void *data, int width, int height);
 void desktopgrab(_Bool video);
 void notify(char_t *title, STRING_IDX title_length, char_t *msg, STRING_IDX msg_length);
 void setscale(void);
-void drawimage(UTOX_NATIVE_IMAGE, int x, int y, int width, int height, int maxwidth, _Bool zoom, double position);
 
-/* draws an image in the style of an avatar at within rect (x,y,targetwidth,targetheight)
- * this means: resize the image while keeping proportion so that the dimension(width or height) that has the smallest rational difference to the targetdimension becomes exactly targetdimension, then
- * crop the image so it fits in the (x,y,targetwidth,targetheight) rect, and
- * set the position if a dimension is too large so it's centered on the middle
- *
- * first argument is the image to draw, width and height are the width and height of the input image
+enum {
+    FILTER_NEAREST, // ugly and quick filtering
+    FILTER_BILINEAR // prettier and a bit slower filtering
+};
+/* set filtering method used when resizing given image to one of above enum */
+void image_set_filter(UTOX_NATIVE_IMAGE *image, uint8_t filter);
+
+/* set scale of image so that when it's drawn it will be `scale' times as large(2.0 for double size, 0.5 for half, etc.)
+ *  notes: theoretically lowest possible scale is (1.0/65536.0), highest is 65536.0, values outside of this range will create weird issues
+ *         scaling will be rounded to pixels, so it might not be exact
  */
-void drawavatarimage(UTOX_NATIVE_IMAGE, int x, int y, int width, int height, int targetwidth, int targetheight);
-UTOX_NATIVE_IMAGE png_to_image(const UTOX_PNG_IMAGE, size_t png_size, uint16_t *w, uint16_t *h);
+void image_set_scale(UTOX_NATIVE_IMAGE *image, double scale);
+
+/* draws an utox image with or without alpha channel into the rect of (x,y,width,height) on the screen,
+ * starting at position (imgx,imgy) of the image */
+void draw_image(const UTOX_NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32_t height, uint32_t imgx, uint32_t imgy);
+
+/* converts a png to a UTOX_NATIVE_IMAGE, returns a pointer to it, keeping alpha channel only if keep_alpha is 1 */
+UTOX_NATIVE_IMAGE *png_to_image(const UTOX_PNG_IMAGE, size_t size, uint16_t *w, uint16_t *h, _Bool keep_alpha);
+
+/* free an image created by png_to_image */
+void image_free(UTOX_NATIVE_IMAGE *image);
+
 void showkeyboard(_Bool show);
 void redraw(void);
 void update_tray(void);

--- a/main.h
+++ b/main.h
@@ -236,7 +236,8 @@ void image_set_scale(UTOX_NATIVE_IMAGE *image, double scale);
 /* draws an utox image with or without alpha channel into the rect of (x,y,width,height) on the screen,
  * starting at position (imgx,imgy) of the image
  * WARNING: Windows can fail to show the image at all if the rect (imgx,imgy,width,height) contains even 1 pixel outside of
- * the image's size AFTER SCALING, so be careful (We might want to improve this so this function is safer to use in the future) */
+ * the image's size AFTER SCALING, so be careful.
+ * TODO: improve this so this function is safer to use */
 void draw_image(const UTOX_NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32_t height, uint32_t imgx, uint32_t imgy);
 
 /* converts a png to a UTOX_NATIVE_IMAGE, returns a pointer to it, keeping alpha channel only if keep_alpha is 1 */

--- a/messages.c
+++ b/messages.c
@@ -25,12 +25,10 @@ static void draw_message_image(UTOX_NATIVE_IMAGE *image, int x, int y, uint32_t 
 {
     if(!zoom && width > maxwidth) {
         image_set_scale(image, (double)maxwidth / width);
-        image_set_filter(image, FILTER_BILINEAR);
 
         draw_image(image, x, y, maxwidth, height * maxwidth / width, 0, 0);
 
         image_set_scale(image, 1.0);
-        image_set_filter(image, FILTER_NEAREST);
     } else {
         if(width > maxwidth) {
             draw_image(image, x, y, maxwidth, height, (int)((double)(width - maxwidth) * position), 0);

--- a/messages.h
+++ b/messages.h
@@ -83,7 +83,7 @@ typedef struct {
     uint16_t w, h;
     _Bool zoom;
     double position;
-    UTOX_NATIVE_IMAGE image;
+    UTOX_NATIVE_IMAGE *image;
 } MSG_IMG;
 
 typedef struct msg_file {

--- a/tox.c
+++ b/tox.c
@@ -287,7 +287,7 @@ static void set_callbacks(Tox *tox)
     utox_set_callbacks_for_transfer(tox);
 }
 
-/* tried to load avatar from disk for given client id string and set avatar based on its result
+/* tries to load avatar from disk for given client id string and set avatar based on saved png data
  *  avatar is avatar to initialize. Will be unset if no file is found on disk or if file is corrupt or too large, 
  *      otherwise will be set to avatar found on disk
  *  id is cid string of whose avatar to find(see also load_avatar in avatar.h)

--- a/ui.c
+++ b/ui.c
@@ -35,14 +35,32 @@ _Bool maybe_i18nal_string_is_valid(MAYBE_I18NAL_STRING *mis) {
 
 /***** MAYBE_I18NAL_STRING helpers end *****/
 
+void draw_avatar_image(UTOX_NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32_t height, uint32_t targetwidth, uint32_t targetheight)
+{
+    /* get smallest difference of width or height */
+    double scale = (abs((int)width - targetwidth) > abs((int)height - targetheight)) ?
+                      (double)targetheight / height :
+                      (double)targetwidth / width;
+
+    image_set_scale(image, scale);
+    image_set_filter(image, FILTER_BILINEAR);
+
+    /* set position to show the middle of the image in the center  */
+    int xpos = (int) ((double)width * scale / 2 - (double)targetwidth / 2);
+    int ypos = (int) ((double)height * scale / 2 - (double)targetheight / 2);
+
+    draw_image(image, x, y, targetwidth, targetheight, xpos, ypos);
+
+    image_set_scale(image, 1.0);
+    image_set_filter(image, FILTER_NEAREST);
+}
+
 uint32_t status_color[] = {
     C_GREEN,
     C_YELLOW,
     C_RED,
     C_RED
 };
-
-/* Draw funcitons to generate Window pages */
 
 /* Top left self interface Avatar, name, statusmsg, status icon */
 static void drawself(void)
@@ -58,7 +76,7 @@ static void drawself(void)
 
     // draw avatar or default image
     if (self_has_avatar()) {
-        drawavatarimage(self.avatar.image, SELF_AVATAR_X, SELF_AVATAR_Y, self.avatar.width, self.avatar.height, BM_CONTACT_WIDTH, BM_CONTACT_WIDTH);
+        draw_avatar_image(self.avatar.image, SELF_AVATAR_X, SELF_AVATAR_Y, self.avatar.width, self.avatar.height, BM_CONTACT_WIDTH, BM_CONTACT_WIDTH);
     } else {
         drawalpha(BM_CONTACT, SELF_AVATAR_X, SELF_AVATAR_Y, BM_CONTACT_WIDTH, BM_CONTACT_WIDTH, WHITE);
     }
@@ -76,7 +94,7 @@ static void drawfriend(int UNUSED(x), int UNUSED(y), int UNUSED(w), int UNUSED(h
 
     // draw avatar or default image
     if (friend_has_avatar(f)) {
-        drawavatarimage(f->avatar.image, LIST_RIGHT + SCALE * 5, SCALE * 5, f->avatar.width, f->avatar.height, BM_CONTACT_WIDTH, BM_CONTACT_WIDTH);
+        draw_avatar_image(f->avatar.image, LIST_RIGHT + SCALE * 5, SCALE * 5, f->avatar.width, f->avatar.height, BM_CONTACT_WIDTH, BM_CONTACT_WIDTH);
     } else {
         drawalpha(BM_CONTACT, LIST_RIGHT + SCALE * 5, SCALE * 5, BM_CONTACT_WIDTH, BM_CONTACT_WIDTH, LIST_MAIN);
     }

--- a/ui.c
+++ b/ui.c
@@ -37,8 +37,8 @@ _Bool maybe_i18nal_string_is_valid(MAYBE_I18NAL_STRING *mis) {
 
 void draw_avatar_image(UTOX_NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32_t height, uint32_t targetwidth, uint32_t targetheight)
 {
-    /* get smallest difference of width or height */
-    double scale = (abs((int)width - targetwidth) > abs((int)height - targetheight)) ?
+    /* get smallest of width or height */
+    double scale = (width > height) ?
                       (double)targetheight / height :
                       (double)targetwidth / width;
 

--- a/ui.h
+++ b/ui.h
@@ -1,3 +1,13 @@
+
+/* draws an image in the style of an avatar at within rect (x,y,targetwidth,targetheight)
+ * this means: resize the image while keeping proportion so that the dimension(width or height) that has the smallest rational difference to the targetdimension becomes exactly targetdimension, then
+ * crop the image so it fits in the (x,y,targetwidth,targetheight) rect, and
+ * set the position if a dimension is too large so it's centered on the middle
+ *
+ * first argument is the image to draw, width and height are the width and height of the input image
+ */
+void draw_avatar_image(UTOX_NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32_t height, uint32_t targetwidth, uint32_t targetheight);
+
 enum
 {
     PANEL_NONE,

--- a/win32/main.c
+++ b/win32/main.c
@@ -149,7 +149,7 @@ void drawalpha(int bm, int x, int y, int width, int height, uint32_t color)
     // each pixel in the alpha bitmap and the color given by 'color',
     // the Win32 API requires we pre-apply our alpha channel as well by
     // doing (color * alpha / 255) for each color channel
-    // NOTE: Input color is in the format 0BGR, output pixel is in the format ARGB
+    // NOTE: Input color is in the format 0BGR, output pixel is in the format BGRA
     while(alpha_pixel != end) {
         uint8_t alpha = *alpha_pixel++;
         *out_pixel++ = (((color & 0xFF) * alpha / 255) << 16) // red

--- a/win32/main.c
+++ b/win32/main.c
@@ -219,8 +219,11 @@ void draw_image(const UTOX_NATIVE_IMAGE *image, int x, int y, uint32_t width, ui
         SelectObject(hdcMem, image->bitmap);
 
         // stretch image onto temporary bitmap
-        StretchBlt(drawdc, 0, 0, image->scaled_width, image->scaled_height, hdcMem, 0, 0, image->width, image->height, SRCCOPY);
-
+        if (image->has_alpha) {
+            AlphaBlend(drawdc, 0, 0, image->scaled_width, image->scaled_height, hdcMem, 0, 0, image->width, image->height, blend_function);
+        } else {
+            StretchBlt(drawdc, 0, 0, image->scaled_width, image->scaled_height, hdcMem, 0, 0, image->width, image->height, SRCCOPY);
+        }
     }
 
     // clip and draw

--- a/win32/main.h
+++ b/win32/main.h
@@ -26,10 +26,10 @@
 
 // internal representation of an image
 typedef struct utox_native_image {
-    HBITMAP rgb; // bitmap representing its RGB channel,
-                 // may not be null
-    HBITMAP alpha; // bitmap representing the alpha channel,
-                   // may be null
+    HBITMAP bitmap; // 32 bit bitmap containing
+                    // red, green, blue and alpha
+
+    _Bool has_alpha; // whether bitmap has an alpha channel
 
     // width and height in pixels of the rgb and alpha
     uint32_t width, height;
@@ -44,4 +44,4 @@ typedef struct utox_native_image {
 } UTOX_NATIVE_IMAGE;
 
 #define UTOX_NATIVE_IMAGE_IS_VALID(x) (NULL != (x))
-#define UTOX_NATIVE_IMAGE_HAS_ALPHA(x) (NULL != (x->alpha))
+#define UTOX_NATIVE_IMAGE_HAS_ALPHA(x) (x->has_alpha)

--- a/win32/main.h
+++ b/win32/main.h
@@ -31,7 +31,7 @@ typedef struct utox_native_image {
 
     _Bool has_alpha; // whether bitmap has an alpha channel
 
-    // width and height in pixels of the rgb and alpha
+    // width and height in pixels of the bitmap
     uint32_t width, height;
 
     // width and height in pixels the image should be drawn to

--- a/win32/main.h
+++ b/win32/main.h
@@ -24,5 +24,24 @@
 #define ftello ftello64
 #endif
 
-typedef HBITMAP UTOX_NATIVE_IMAGE;
+// internal representation of an image
+typedef struct utox_native_image {
+    HBITMAP rgb; // bitmap representing its RGB channel,
+                 // may not be null
+    HBITMAP alpha; // bitmap representing the alpha channel,
+                   // may be null
+
+    // width and height in pixels of the rgb and alpha
+    uint32_t width, height;
+
+    // width and height in pixels the image should be drawn to
+    uint32_t scaled_width, scaled_height;
+
+    // stretch mode used when stretching this image, either
+    // COLORONCOLOR(ugly and fast), or HALFTONE(prettier and slower)
+    int stretch_mode;
+
+} UTOX_NATIVE_IMAGE;
+
 #define UTOX_NATIVE_IMAGE_IS_VALID(x) (NULL != (x))
+#define UTOX_NATIVE_IMAGE_HAS_ALPHA(x) (NULL != (x->alpha))

--- a/xlib/event.c
+++ b/xlib/event.c
@@ -223,9 +223,11 @@ _Bool doevent(XEvent event)
 
                             uint16_t w = img->width;
                             uint16_t h = img->height;
-                            Picture pic = image_to_picture(img);
 
-                            friend_sendimage(f, pic, w, h, (UTOX_PNG_IMAGE)out, size);
+                            UTOX_NATIVE_IMAGE *image = malloc(sizeof(UTOX_NATIVE_IMAGE));
+                            image->rgb = ximage_to_picture(img, NULL);
+                            image->alpha = None;
+                            friend_sendimage(f, image, w, h, (UTOX_PNG_IMAGE)out, size);
                         }
                     }
                 } else {

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -177,6 +177,47 @@ void postmessage(uint32_t msg, uint16_t param1, uint16_t param2, void *data)
     XFlush(display);
 }
 
+void image_set_scale(UTOX_NATIVE_IMAGE *image, double scale)
+{
+    uint32_t r = (uint32_t)(65536.0 / scale);
+
+    /* transformation matrix to scale image */
+    XTransform trans = {
+        {{r, 0, 0},
+         {0, r, 0},
+         {0, 0, 65536}}
+    };
+    XRenderSetPictureTransform(display, image->rgb, &trans);
+    if (image->alpha) {
+        XRenderSetPictureTransform(display, image->alpha, &trans);
+    }
+}
+
+void image_set_filter(UTOX_NATIVE_IMAGE *image, uint8_t filter)
+{
+    const char *xfilter;
+    switch (filter) {
+    case FILTER_NEAREST:
+        xfilter = FilterNearest;
+        break;
+    case FILTER_BILINEAR:
+        xfilter = FilterBilinear;
+        break;
+    default:
+        debug("Warning: Tried to set image to unrecognized filter(%u).\n", filter);
+        return;
+    }
+    XRenderSetPictureFilter(display, image->rgb, xfilter, NULL, 0);
+    if (image->alpha) {
+        XRenderSetPictureFilter(display, image->alpha, xfilter, NULL, 0);
+    }
+}
+
+void draw_image(const UTOX_NATIVE_IMAGE *image, int x, int y, uint32_t width, uint32_t height, uint32_t imgx, uint32_t imgy)
+{
+    XRenderComposite(display, PictOpOver, image->rgb, image->alpha, renderpic, imgx, imgy, imgx, imgy, x, y, width, height);
+}
+
 void drawalpha(int bm, int x, int y, int width, int height, uint32_t color)
 {
     XRenderColor xrcolor = {
@@ -191,75 +232,6 @@ void drawalpha(int bm, int x, int y, int width, int height, uint32_t color)
     XRenderComposite(display, PictOpOver, src, bitmap[bm], renderpic, 0, 0, 0, 0, x, y, width, height);
 
     XRenderFreePicture(display, src);
-}
-
-void drawimage(UTOX_NATIVE_IMAGE data, int x, int y, int width, int height, int maxwidth, _Bool zoom, double position)
-{
-    Picture bm = data;
-    if(!zoom && width > maxwidth) {
-        uint32_t v = (width * 65536) / maxwidth;
-        XTransform trans = {
-            {{v, 0, 0},
-            {0, v, 0},
-            {0, 0, 65536}}
-        };
-        XRenderSetPictureTransform(display, bm, &trans);
-        XRenderSetPictureFilter(display, bm, FilterBilinear, NULL, 0);
-
-        XRenderComposite(display, PictOpSrc, bm, None, renderpic, 0, 0, 0, 0, x, y, maxwidth, height * maxwidth / width);
-
-        XTransform trans2 = {
-            {{65536, 0, 0},
-            {0, 65536, 0},
-            {0, 0, 65536}}
-        };
-        XRenderSetPictureFilter(display, bm, FilterNearest, NULL, 0);
-        XRenderSetPictureTransform(display, bm, &trans2);
-    } else {
-        if(width > maxwidth) {
-            XRenderComposite(display, PictOpSrc, bm, None, renderpic, (int)((double)(width - maxwidth) * position), 0, 0, 0, x, y, maxwidth, height);
-        } else {
-            XRenderComposite(display, PictOpSrc, bm, None, renderpic, 0, 0, 0, 0, x, y, width, height);
-        }
-    }
-}
-
-void drawavatarimage(UTOX_NATIVE_IMAGE data, int x, int y, int width, int height, int targetwidth, int targetheight)
-{
-    Picture bm = data;
-
-    uint32_t resize;
-    {
-        /* get smallest rational difference of width or height */
-        uint32_t w_resize = (width * 65536) / targetwidth;
-        uint32_t h_resize = (height * 65536) / targetheight;
-        resize = (abs((int)w_resize - 65536) > abs((int)h_resize - 65536)) ? h_resize : w_resize;
-    }
-
-    /* transformation matrix to scale image to mostly fit within target dimensions */
-    XTransform trans = {
-        {{resize, 0, 0},
-        {0, resize, 0},
-        {0, 0, 65536}}
-    };
-    XRenderSetPictureTransform(display, bm, &trans);
-    XRenderSetPictureFilter(display, bm, FilterBilinear, NULL, 0);
-
-    /* set position to show the middle of the image in the center  */
-    int xpos = (int) ((double)width * 65536 / resize / 2 - (double)targetwidth / 2);
-    int ypos = (int) ((double)height * 65536 / resize / 2 - (double)targetheight / 2);
-
-    /* draw the image */
-    XRenderComposite(display, PictOpSrc, bm, None, renderpic, xpos, ypos, 0, 0, x, y, targetwidth, targetheight);
-
-    /* reset matrix and filter */
-    XTransform trans2 = {
-        {{65536, 0, 0},
-        {0, 65536, 0},
-        {0, 0, 65536}}
-    };
-    XRenderSetPictureFilter(display, bm, FilterNearest, NULL, 0);
-    XRenderSetPictureTransform(display, bm, &trans2);
 }
 
 static int _drawtext(int x, int xmax, int y, char_t *str, STRING_IDX length)
@@ -610,7 +582,7 @@ static void pastedata(void *data, Atom type, int len, _Bool select)
    if (type == XA_PNG_IMG) {
         uint16_t width, height;
 
-        UTOX_NATIVE_IMAGE native_image = png_to_image(data, size, &width, &height);
+        UTOX_NATIVE_IMAGE *native_image = png_to_image(data, size, &width, &height, 0);
         if (UTOX_NATIVE_IMAGE_IS_VALID(native_image)) {
             debug("Pasted image: %dx%d\n", width, height);
 
@@ -627,68 +599,105 @@ static void pastedata(void *data, Atom type, int len, _Bool select)
     }
 }
 
-void loadalpha(int bm, void *data, int width, int height)
+static Picture ximage_to_picture(XImage *img, const XRenderPictFormat *format)
 {
-    Pixmap pixmap = XCreatePixmap(display, window, width, height, 8);
-    XImage *img = XCreateImage(display, CopyFromParent, 8, ZPixmap, 0, data, width, height, 8, 0);
-    GC legc = XCreateGC(display, pixmap, 0, NULL);
-    XPutImage(display, pixmap, legc, img, 0, 0, 0, 0, width, height);
-
-    Picture picture = XRenderCreatePicture(display, pixmap, XRenderFindStandardFormat(display, PictStandardA8), 0, NULL);
-
-    XFreeGC(display, legc);
-    XFreePixmap(display, pixmap);
-
-    bitmap[bm] = picture;
-}
-
-static Picture image_to_picture(XImage *img)
-{
-    Pixmap pixmap = XCreatePixmap(display, window, img->width, img->height, 24);
+    Pixmap pixmap = XCreatePixmap(display, window, img->width, img->height, img->depth);
     GC legc = XCreateGC(display, pixmap, 0, NULL);
     XPutImage(display, pixmap, legc, img, 0, 0, 0, 0, img->width, img->height);
 
-    Picture picture = XRenderCreatePicture(display, pixmap, XRenderFindVisualFormat(display, visual), 0, NULL);
+    if (format == NULL) {
+        format = XRenderFindVisualFormat(display, visual);
+    }
+    Picture picture = XRenderCreatePicture(display, pixmap, format, 0, NULL);
 
     XFreeGC(display, legc);
     XFreePixmap(display, pixmap);
-    //XDestroyImage(img);
 
     return picture;
 }
 
-UTOX_NATIVE_IMAGE png_to_image(const UTOX_PNG_IMAGE data, size_t size, uint16_t *w, uint16_t *h)
+void loadalpha(int bm, void *data, int width, int height)
 {
-    uint8_t *out;
+    XImage *img = XCreateImage(display, CopyFromParent, 8, ZPixmap, 0, data, width, height, 8, 0);
+
+    bitmap[bm] = ximage_to_picture(img, XRenderFindStandardFormat(display, PictStandardA8));
+}
+
+
+/* generates an alpha bitmask based on the alpha channel in given rgba_data
+ * returned picture will have 1 byte for each pixel, and have the same width and height as input
+ */
+static Picture generate_alpha_bitmask(const uint8_t *rgba_data, uint16_t width, uint16_t height, uint32_t rgba_size)
+{
+    uint8_t *out = malloc(rgba_size / 4);
+    uint32_t i, j;
+    for (i = j = 0; i < rgba_size; i += 4, j++) {
+        out[j] = (rgba_data+i)[3] & 0xFF; // take only alpha values
+    }
+
+    XImage *img = XCreateImage(display, CopyFromParent, 8, ZPixmap, 0, (char*)out, width, height, 8, width);
+    Picture picture = ximage_to_picture(img, XRenderFindStandardFormat(display, PictStandardA8));
+
+    XDestroyImage(img);
+
+    return picture;
+}
+
+UTOX_NATIVE_IMAGE *png_to_image(const UTOX_PNG_IMAGE data, size_t size, uint16_t *w, uint16_t *h, _Bool keep_alpha)
+{
+    uint8_t *rgba_data;
     unsigned width, height;
-    unsigned r = lodepng_decode32(&out, &width, &height, data->png_data, size);
+    unsigned r = lodepng_decode32(&rgba_data, &width, &height, data->png_data, size);
 
     if(r != 0 || !width || !height) {
-        return None;
+        return None; // invalid png data
     }
+
+    uint32_t rgba_size = width * height * 4;
+
+    // we don't need to free this, that's done by XDestroyImage()
+    uint8_t *out = malloc(rgba_size);
 
     uint8_t red, blue, green;
-    uint8_t *p, *end = out + width * height * 4;
-    uint32_t *temp;
+    uint32_t *target;
 
-    for (p = out; p != end; p += 4) {
-        red = p[0] & 0xFF;
-        green = p[1] & 0xFF;
-        blue = p[2] & 0xFF;
+    uint32_t i;
+    for (i = 0; i < rgba_size; i += 4) {
+        red = (rgba_data+i)[0] & 0xFF;
+        green = (rgba_data+i)[1] & 0xFF;
+        blue = (rgba_data+i)[2] & 0xFF;
 
-        temp = (uint32_t *)p;
-        *temp = (red | (red << 8) | (red << 16) | (red << 24)) & visual->red_mask;
-        *temp |= (blue | (blue << 8) | (blue << 16) | (blue << 24)) & visual->blue_mask;
-        *temp |= (green | (green << 8) | (green << 16) | (green << 24)) & visual->green_mask;
+        target = (uint32_t *)(out+i);
+        *target = (red | (red << 8) | (red << 16) | (red << 24)) & visual->red_mask;
+        *target |= (blue | (blue << 8) | (blue << 16) | (blue << 24)) & visual->blue_mask;
+        *target |= (green | (green << 8) | (green << 16) | (green << 24)) & visual->green_mask;
     }
+
+    XImage *img = XCreateImage(display, visual, 24, ZPixmap, 0, (char*)out, width, height, 32, width * 4);
+
+    Picture rgb = ximage_to_picture(img, NULL);
+    Picture alpha = (keep_alpha) ? generate_alpha_bitmask(rgba_data, width, height, rgba_size) : None;
+
+    free(rgba_data);
 
     *w = width;
     *h = height;
-    XImage *img = XCreateImage(display, visual, 24, ZPixmap, 0, (char*)out, width, height, 32, width * 4);
-    Picture picture = image_to_picture(img);
-    free(out);
 
-    return picture;
+    UTOX_NATIVE_IMAGE *image = malloc(sizeof(UTOX_NATIVE_IMAGE));
+    image->rgb = rgb;
+    image->alpha = alpha;
+
+    XDestroyImage(img);
+    return image;
+}
+
+void image_free(UTOX_NATIVE_IMAGE *image)
+{
+    XRenderFreePicture(display, image->rgb);
+    if (image->alpha) {
+        XRenderFreePicture(display, image->alpha);
+    }
+    free(image);
 }
 
 int datapath_old(uint8_t *dest)

--- a/xlib/main.h
+++ b/xlib/main.h
@@ -33,7 +33,12 @@
 
 #define KEY(x) (x + 'a' - 'A')
 
-// This is really a Picture, but it is just a typedef for XID, and I didn't
-// want to clutter namespace with #include <X11/extensions/Xrender.h> for it.
-typedef XID UTOX_NATIVE_IMAGE;
+typedef struct utox_native_image {
+    // This is really a Picture, but it is just a typedef for XID, and I didn't
+    // want to clutter namespace with #include <X11/extensions/Xrender.h> for it.
+    XID rgb;
+    XID alpha;
+} UTOX_NATIVE_IMAGE;
+
 #define UTOX_NATIVE_IMAGE_IS_VALID(x) (None != (x))
+#define UTOX_NATIVE_IMAGE_HAS_ALPHA(x) (None != (x->alpha))


### PR DESCRIPTION
solves #729

Notes:

 - Because this changes the entire structure of images(allowing them to have transparency), this changes a lot of the image-related functions. This breaks images on android.
 - While refactoring to avoid code duplication, I saw opportunity to move drawimage and drawavatarimage to crossplatform code, so I did. drawimage has become draw_message_image in message.c(the only place it is used), and drawavatarimage has become draw_avatar_image in ui.c, which seemed the best place for it. The platform-defined functions for image drawing are now image_set_filter, image_set_scale and draw_image.
 - images can actually be cleaned up now (use image_free)
 - [FIXED] alpha bitmasks only use up 1 byte per pixel on Xlib, but unnecessarily use up 4 bytes per pixel on Windows. I couldn't find out how to fix that after a lot searching and trying stuff, so I found it wasn't worth it to go on with it. Could always be fixed in the future.
 - [FIXED] I found out while testing this that images with alpha look terrible at the edges on Windows. However, this is not a regression. It was already like that when avatars were introduced. There should be a way to fix this, as images use alpha in a pretty way in the drawalpha function too.

Example (on Wine)
![tav2](https://cloud.githubusercontent.com/assets/10358736/5790062/1680ca46-9e88-11e4-8e10-152bdd15443d.png)

