### PR TITLE
fflush stdout on debug, because win32 needs some poking

### DIFF
--- a/win32/main.h
+++ b/win32/main.h
@@ -15,7 +15,7 @@
 #define KEY_PAGEUP VK_PRIOR
 #define KEY_PAGEDOWN VK_NEXT
 
-#define debug(...) printf(__VA_ARGS__)
+#define debug(...) printf(__VA_ARGS__); fflush(stdout)
 
 #define KEY(x) (x)
 


### PR DESCRIPTION
This took a really long time to realize it wasn't something I f'ed up. Now debugging is manageable on cygwin systems.