### PR TITLE
Adding avatars to the notifications using DBus

### DIFF
--- a/android/main.c
+++ b/android/main.c
@@ -213,7 +213,7 @@ void setscale(void)
     }
 }
 
-void notify(char_t *title, STRING_IDX title_length, char_t *msg, STRING_IDX msg_length)
+void notify(char_t *title, STRING_IDX title_length, char_t *msg, STRING_IDX msg_length, uint8_t *cid)
 {
 }
 

--- a/avatar.h
+++ b/avatar.h
@@ -14,6 +14,15 @@ typedef struct avatar {
 /* whether friend f's avatar is set, where f is a pointer to a friend struct */
 #define friend_has_avatar(f) (f->avatar.format != TOX_AVATAR_FORMAT_NONE)
 
+/* gets the avatar location on the diskloads an avatar from disk and puts the result in dest.
+ * id is the client id string for given client. To get the cid string from a cid, use cid_to_string
+ *   id should be at least (TOX_CLIENT_ID_SIZE * 2) bytes long
+ *  on success: returns the number of chars written
+ *  on failure: returns 0
+ *  notes: dest should be at least TOX_AVATAR_MAX_DATA_LENGTH bytes long.
+ */
+int get_avatar_location(char_t *dest, const char_t *id);
+
 /* loads an avatar from disk and puts the resulting png data in buffer given by dest.
  * id is the client id string for given client. To get the cid string from a cid, use cid_to_string
  *   id should be at least (TOX_CLIENT_ID_SIZE * 2) bytes long

--- a/avatar.h
+++ b/avatar.h
@@ -14,12 +14,9 @@ typedef struct avatar {
 /* whether friend f's avatar is set, where f is a pointer to a friend struct */
 #define friend_has_avatar(f) (f->avatar.format != TOX_AVATAR_FORMAT_NONE)
 
-/* gets the avatar location on the diskloads an avatar from disk and puts the result in dest.
+/* gets the avatar location on the disk and puts the result in dest.
  * id is the client id string for given client. To get the cid string from a cid, use cid_to_string
- *   id should be at least (TOX_CLIENT_ID_SIZE * 2) bytes long
- *  on success: returns the number of chars written
- *  on failure: returns 0
- *  notes: dest should be at least TOX_AVATAR_MAX_DATA_LENGTH bytes long.
+ *  returns the number of chars written
  */
 int get_avatar_location(char_t *dest, const char_t *id);
 

--- a/friend.c
+++ b/friend.c
@@ -70,6 +70,8 @@ void friend_recvimage(FRIEND *f, UTOX_PNG_IMAGE png_image, size_t png_size)
 void friend_notify(FRIEND *f, char_t *str, STRING_IDX str_length, char_t *msg, STRING_IDX msg_length)
 {
     int len = f->name_length + str_length + 3;
+    uint8_t *f_cid = NULL;
+    
     char_t title[len + 1], *p = title;
     memcpy(p, str, str_length); p += str_length;
     *p++ = ' ';
@@ -77,7 +79,11 @@ void friend_notify(FRIEND *f, char_t *str, STRING_IDX str_length, char_t *msg, S
     memcpy(p, f->name, f->name_length); p += f->name_length;
     *p++ = ')';
     *p = 0;
-    notify(title, len, msg, msg_length);
+    
+    if(friend_has_avatar(f))
+        f_cid = f->cid;
+    
+    notify(title, len, msg, msg_length, f_cid);
 }
 
 void friend_addmessage_notify(FRIEND *f, char_t *data, STRING_IDX length)
@@ -109,7 +115,7 @@ void friend_addmessage(FRIEND *f, void *data)
         char_t m[msg->length + 1];
         memcpy(m, msg->msg, msg->length);
         m[msg->length] = 0;
-        notify(f->name, f->name_length, m, msg->length);
+        notify(f->name, f->name_length, m, msg->length, f->cid);
         break;
     }
     }

--- a/friend.c
+++ b/friend.c
@@ -80,8 +80,9 @@ void friend_notify(FRIEND *f, char_t *str, STRING_IDX str_length, char_t *msg, S
     *p++ = ')';
     *p = 0;
     
-    if(friend_has_avatar(f))
+    if(friend_has_avatar(f)) {
         f_cid = f->cid;
+    }
     
     notify(title, len, msg, msg_length, f_cid);
 }

--- a/main.h
+++ b/main.h
@@ -217,7 +217,7 @@ enum
 void drawalpha(int bm, int x, int y, int width, int height, uint32_t color);
 void loadalpha(int bm, void *data, int width, int height);
 void desktopgrab(_Bool video);
-void notify(char_t *title, STRING_IDX title_length, char_t *msg, STRING_IDX msg_length);
+void notify(char_t *title, STRING_IDX title_length, char_t *msg, STRING_IDX msg_length, uint8_t *cid);
 void setscale(void);
 void drawimage(UTOX_NATIVE_IMAGE, int x, int y, int width, int height, int maxwidth, _Bool zoom, double position);
 

--- a/win32/main.c
+++ b/win32/main.c
@@ -880,7 +880,7 @@ void flush_file(FILE *file)
  * accepts: char_t *title, title legnth, char_t *msg, msg length;
  * returns void;
  */
-void notify(char_t *title, STRING_IDX title_length, char_t *msg, STRING_IDX msg_length)
+void notify(char_t *title, STRING_IDX title_length, char_t *msg, STRING_IDX msg_length, uint8_t *cid)
 {
     if(havefocus) {
         return;

--- a/xlib/dbus.c
+++ b/xlib/dbus.c
@@ -1,6 +1,5 @@
 #include <dbus/dbus.h>
 #include <signal.h>
-#include "../util.h"
 
 #define NOTIFY_OBJECT "/org/freedesktop/Notifications"
 #define NOTIFY_INTERFACE "org.freedesktop.Notifications"
@@ -12,7 +11,6 @@ static int notify_build_message(DBusMessage* notify_msg, char *title, char *cont
     DBusMessageIter args[4];
     char *app_name = "uTox";
     uint32_t replaces_id = -1;
-    char_t string_cid[TOX_CLIENT_ID_SIZE * 2];
     char_t app_icon_data[256];
     char *app_icon = "";
     int32_t timeout = 5000;
@@ -23,6 +21,7 @@ static int notify_build_message(DBusMessage* notify_msg, char *title, char *cont
     // Gets the avatar of the user to be displayed in the notification
     if(cid != NULL)
     {
+        char_t string_cid[TOX_CLIENT_ID_SIZE * 2];
         cid_to_string(string_cid, cid);
         get_avatar_location(app_icon_data, string_cid);
         app_icon = (char*) app_icon_data;

--- a/xlib/dbus.c
+++ b/xlib/dbus.c
@@ -1,22 +1,33 @@
 #include <dbus/dbus.h>
 #include <signal.h>
+#include "../util.h"
 
 #define NOTIFY_OBJECT "/org/freedesktop/Notifications"
 #define NOTIFY_INTERFACE "org.freedesktop.Notifications"
 
 static sig_atomic_t  done;
 
-static int notify_build_message(DBusMessage* notify_msg, char *title, char *content)
+static int notify_build_message(DBusMessage* notify_msg, char *title, char *content, uint8_t *cid)
 {
     DBusMessageIter args[4];
     char *app_name = "uTox";
     uint32_t replaces_id = -1;
+    char_t string_cid[TOX_CLIENT_ID_SIZE * 2];
+    char_t app_icon_data[256];
     char *app_icon = "";
     int32_t timeout = 5000;
     dbus_bool_t m = 0;
     char* key = "foo";
     int value = 42;
 
+    // Gets the avatar of the user to be displayed in the notification
+    if(cid != NULL)
+    {
+        cid_to_string(string_cid, cid);
+        get_avatar_location(app_icon_data, string_cid);
+        app_icon = (char*) app_icon_data;
+    }
+    
     dbus_message_iter_init_append(notify_msg, &args[0]);
     m |= dbus_message_iter_append_basic(&args[0], DBUS_TYPE_STRING, &app_name);
     m |= dbus_message_iter_append_basic(&args[0], DBUS_TYPE_UINT32, &replaces_id);
@@ -47,7 +58,7 @@ static void notify_callback(DBusPendingCall* pending, void* user_data)
     done = 1;
 }
 
-void dbus_notify(char *title, char *content)
+void dbus_notify(char *title, char *content, uint8_t *cid)
 {
     DBusMessage *msg;
     DBusConnection* conn;
@@ -80,7 +91,7 @@ void dbus_notify(char *title, char *content)
     /* append arguments
     UINT32 org.freedesktop.Notifications.Notify (STRING app_name, UINT32 replaces_id, STRING app_icon, STRING summary, STRING body, ARRAY actions, DICT hints, INT32 expire_timeout); */
 
-    if(!notify_build_message(msg, title, content)) {
+    if(!notify_build_message(msg, title, content, cid)) {
         //fprintf(stderr, "Out Of Memory!\n");
         return;
     }

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -766,7 +766,7 @@ void setscale(void)
     }
 }
 
-void notify(char_t *title, STRING_IDX title_length, char_t *msg, STRING_IDX msg_length)
+void notify(char_t *title, STRING_IDX title_length, char_t *msg, STRING_IDX msg_length, uint8_t *cid)
 {
     if(havefocus) {
         return;
@@ -778,7 +778,7 @@ void notify(char_t *title, STRING_IDX title_length, char_t *msg, STRING_IDX msg_
     #ifdef HAVE_DBUS
     char_t *str = tohtml(msg, msg_length);
 
-    dbus_notify((char*)title, (char*)str);
+    dbus_notify((char*)title, (char*)str, (uint8_t*)cid);
 
     free(str);
     #endif


### PR DESCRIPTION
I discussed with irungentoo (and other contributrors) on IRC about this "new feature" dealing with integration in GNU/Linux systems using DBus.

Now, when one receives a message from a friend and if uTox is minimized, the notification sent shows the avatar of the other friend next to the "name" and "message".

Exemple on Ubuntu in the picture bellow:
![notification_with_avatar](https://cloud.githubusercontent.com/assets/9038199/5822632/0761ccc2-a0d6-11e4-9c14-1148337cfaac.png)