### PR TITLE
redraw when mouse leaves window

### DIFF
--- a/tooltip.h
+++ b/tooltip.h
@@ -9,7 +9,9 @@ typedef struct tooltip {
     MAYBE_I18NAL_STRING* tt_text;
 } TOOLTIP;
 
+// removes the tooltip, requires a redraw
 void tooltip_reset(void);
+
 void tooltip_draw(void);
 _Bool tooltip_mmove(void);
 _Bool tooltip_mdown(void);

--- a/ui.c
+++ b/ui.c
@@ -968,6 +968,7 @@ void ui_mouseleave(void)
 {
     panel_mleave(&panel_main);
     tooltip_reset();
+    redraw();
 }
 
 static void panel_draw_sub(PANEL *p, int x, int y, int width, int height)


### PR DESCRIPTION
This fixes tooltips staying after your mouse left the window very quickly on Windows.