### PR TITLE
Change the Version field in utox.desktop to a correct value

### DIFF
--- a/utox.desktop
+++ b/utox.desktop
@@ -1,4 +1,5 @@
 [Desktop Entry]
+Version=1.0
 Type=Application
 Name=uTox
 Comment=A lightweight Tox client

--- a/utox.desktop
+++ b/utox.desktop
@@ -1,11 +1,10 @@
 [Desktop Entry]
-Version=0.18
 Type=Application
 Name=uTox
 Comment=A lightweight Tox client
 TryExec=utox
 Exec=utox
 Icon=utox
-Categories=InstantMessaging;;AudioVideo;Network;
+Categories=InstantMessaging;AudioVideo;Network;
 Terminal=false
 MimeType=x-scheme-handler/tox;


### PR DESCRIPTION
From the the [Desktop Entry Specification][0]:
> Version of the Desktop Entry Specification that the desktop entry conforms with. **Entries that confirm with this version of the specification should use 1.0.** Note that the version field is not required to be present.

(emphasis added)

[0]: http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html#key-version