### PR TITLE
Fix chat header divider overlap

### DIFF
--- a/ui.c
+++ b/ui.c
@@ -312,7 +312,7 @@ static void background_draw(PANEL *UNUSED(p), int UNUSED(x), int UNUSED(y), int 
     drawrect(LIST_RIGHT, 0, width, height, COLOR_MAIN_BACKGROUND);
     
     // Chat and chat header separation
-    drawhline(LIST_RIGHT, LIST_Y, width, COLOR_EDGE_NORMAL);
+    drawhline(LIST_RIGHT, LIST_Y - 1, width, COLOR_EDGE_NORMAL);
 }
 
 static _Bool background_mmove(PANEL *UNUSED(p), int UNUSED(x), int UNUSED(y), int UNUSED(width), int UNUSED(height), int UNUSED(mx), int UNUSED(my), int UNUSED(dx), int UNUSED(dy))

--- a/ui.h
+++ b/ui.h
@@ -149,7 +149,7 @@ uint8_t SCALE;
 
 #define MESSAGES_BOTTOM (-47 * SCALE)
 
-#define SEARCH_Y (31 * SCALE)
+#define SEARCH_Y (31 * SCALE) - 1
 
 /* main */
 //#define MAIN_X


### PR DESCRIPTION
Fixing the issue, reported by @tsudoko :+1: 

![fix](https://cloud.githubusercontent.com/assets/7157049/6536332/9e49f01a-c444-11e4-9168-5213241b6bfd.png)

----

Chat and settings contents start right at `LIST_Y` height. So header line should be right above it. Search and filter input top should match the line, so they are moved 1px up too.