### PR TITLE
Fix edit form not losing focus when it should

### DIFF
--- a/edit.c
+++ b/edit.c
@@ -225,7 +225,8 @@ _Bool edit_mright(EDIT *edit)
 
         return 1;
     } else if (active_edit == edit) {
-        setactive(NULL); // lose focus if right mouse button is pressed somewhere else
+        edit_resetfocus(); // lose focus if right mouse button is pressed somewhere else
+        return 1; // redraw
     }
 
     return 0;

--- a/edit.c
+++ b/edit.c
@@ -224,6 +224,8 @@ _Bool edit_mright(EDIT *edit)
         contextmenu_new(countof(menu_edit), menu_edit, contextmenu_edit_onselect);
 
         return 1;
+    } else if (active_edit == edit) {
+        setactive(NULL); // lose focus if right mouse button is pressed somewhere else
     }
 
     return 0;

--- a/list.c
+++ b/list.c
@@ -232,7 +232,7 @@ static void selectitem(ITEM *i)
         messages_group.iover = MSG_IDX_MAX;
         messages_group.panel.content_scroll->content_height = g->msg.height;
         messages_group.panel.content_scroll->d = g->msg.scroll;
-        edit_setfocus(&edit_msg);
+        edit_setfocus(&edit_msg_group);
 
         g->msg.id = g - group;
 

--- a/ui.c
+++ b/ui.c
@@ -475,8 +475,10 @@ panel_item[] = {
         .drawfunc = drawgroup,
         .child = (PANEL*[]) {
             (void*)&button_group_audio,
-            (void*)&scroll_group, (void*)&messages_group,
-            (void*)&edit_msg_group, (void*)&button_chat_send,
+            (void*)&edit_msg_group,
+            (void*)&scroll_group,
+            (void*)&messages_group,
+            (void*)&button_chat_send,
             NULL
         }
     },

--- a/ui.h
+++ b/ui.h
@@ -54,7 +54,7 @@ enum
 
 extern PANEL panel_main, panel_item[];
 extern MESSAGES messages_friend, messages_group;
-extern EDIT edit_name, edit_status, edit_addid, edit_addmsg, edit_msg, edit_search, edit_proxy_ip, edit_proxy_port;
+extern EDIT edit_name, edit_status, edit_addid, edit_addmsg, edit_msg, edit_msg_group, edit_search, edit_proxy_ip, edit_proxy_port;
 extern SCROLLABLE scroll_list;
 extern BUTTON button_add, button_settings, button_transfer;
 


### PR DESCRIPTION
This fixes #840. You couldn't copy from groupchats because it didn't reset the focus when selecting text.