### PR TITLE
Forbid adding offline users to groups

### DIFF
--- a/list.c
+++ b/list.c
@@ -626,7 +626,9 @@ _Bool list_mup(void *UNUSED(n))
                     FRIEND *f = sitem->data;
                     GROUPCHAT *g = nitem->data;
 
-                    tox_postmessage(TOX_GROUPINVITE, (g - group), (f - friend), NULL);
+                    if(f->online) {
+                        tox_postmessage(TOX_GROUPINVITE, (g - group), (f - friend), NULL);
+                    }
                 }
 
             }


### PR DESCRIPTION
uTox allowed adding offline users to chat groups which corrupted the group somehow.