### PR TITLE
~Hotfix~ (coldfix) file size exploit && file resume storage info.

### DIFF
--- a/android/main.c
+++ b/android/main.c
@@ -8,6 +8,7 @@
 
 #include <GLES2/gl2.h>
 
+#define _GNU_SOURCE
 #include <fcntl.h>
 #include <sys/mman.h>
 
@@ -238,6 +239,10 @@ void flush_file(FILE *file)
     fflush(file);
     int fd = fileno(file);
     fsync(fd);
+}
+
+int resize_file(FILE *file, uint64_t size){
+    // File transfers unsupported on android TODO
 }
 
 int ch_mod(uint8_t *file){

--- a/file_transfers.c
+++ b/file_transfers.c
@@ -1064,6 +1064,10 @@ void utox_cleanup_file_transfers(uint32_t friend_number, uint32_t file_number){
             free(transfer->memory);
         }
     }
+
+    if(transfer->file){
+        fclose(transfer->file);
+    }
 }
 
 void utox_file_save_ftinfo(FILE_TRANSFER *file){

--- a/file_transfers.c
+++ b/file_transfers.c
@@ -71,10 +71,18 @@ static int utox_file_alloc_ftinfo(FILE_TRANSFER *file){
     uint8_t path[UTOX_FILE_NAME_LENGTH];
     size_t path_length;
     path_length = datapath(path);
-    uint8_t hex_id[TOX_FILE_ID_LENGTH * 2];
-    fid_to_string(hex_id, file->file_id);
-    memcpy((path + path_length), hex_id, TOX_FILE_ID_LENGTH * 2);
-    strcpy((char*)(path + (path_length + TOX_FILE_ID_LENGTH * 2)), ".ftinfo");
+
+    if(file->incoming){
+        uint8_t hex_id[TOX_FILE_ID_LENGTH * 2];
+        fid_to_string(hex_id, file->file_id);
+        memcpy(path + path_length, hex_id, TOX_FILE_ID_LENGTH * 2);
+        strcpy((char*)path + (path_length + TOX_FILE_ID_LENGTH * 2), ".ftinfo");
+    } else {
+        uint8_t hex_id[TOX_PUBLIC_KEY_SIZE * 2];
+        cid_to_string(hex_id, friend[file->friend_number].cid);
+        memcpy(path + path_length, hex_id, TOX_PUBLIC_KEY_SIZE * 2);
+        sprintf((char*)path + (path_length + TOX_PUBLIC_KEY_SIZE * 2), "%02i.ftinfo", file->file_number % 100);
+    }
 
     FILE *saveinfo = fopen((const char*)path, "wb");
     if(!file) {
@@ -91,10 +99,19 @@ static void utox_file_free_ftinfo(FILE_TRANSFER *file){
         uint8_t path[UTOX_FILE_NAME_LENGTH];
         size_t path_length;
         path_length = datapath(path);
-        uint8_t hex_id[TOX_FILE_ID_LENGTH * 2];
-        fid_to_string(hex_id, file->file_id);
-        memcpy((path + path_length), hex_id, TOX_FILE_ID_LENGTH * 2);
-        strcpy((char*)(path + (path_length + TOX_FILE_ID_LENGTH * 2)), ".ftinfo");
+
+        if(file->incoming){
+            uint8_t hex_id[TOX_FILE_ID_LENGTH * 2];
+            fid_to_string(hex_id, file->file_id);
+            memcpy(path + path_length, hex_id, TOX_FILE_ID_LENGTH * 2);
+            strcpy((char*)path + (path_length + TOX_FILE_ID_LENGTH * 2), ".ftinfo");
+        } else {
+            uint8_t hex_id[TOX_PUBLIC_KEY_SIZE * 2];
+            cid_to_string(hex_id, friend[file->friend_number].cid);
+            memcpy(path + path_length, hex_id, TOX_PUBLIC_KEY_SIZE * 2);
+            sprintf((char*)path + (path_length + TOX_PUBLIC_KEY_SIZE * 2), "%02i.ftinfo", file->file_number % 100);
+        }
+
         remove((const char*)path);
     }
 }

--- a/file_transfers.c
+++ b/file_transfers.c
@@ -1,9 +1,8 @@
 #include "main.h"
 
 //static FILE_TRANSFER *file_t[256], **file_tend = file_t;
-static FILE_TRANSFER outgoing_transfer[MAX_NUM_FRIENDS][MAX_FILE_TRANSFERS];
-static FILE_TRANSFER incoming_transfer[MAX_NUM_FRIENDS][MAX_FILE_TRANSFERS];
-static BROKEN_TRANSFER broken_list[MAX_FILE_TRANSFERS] = {{0}};
+static FILE_TRANSFER outgoing_transfer[MAX_NUM_FRIENDS][MAX_FILE_TRANSFERS] = {{{0}}};
+static FILE_TRANSFER incoming_transfer[MAX_NUM_FRIENDS][MAX_FILE_TRANSFERS] = {{{0}}};
 
 // Remove if supported by core
 #define TOX_FILE_KIND_EXISTING 3
@@ -61,85 +60,42 @@ static void calculate_speed(FILE_TRANSFER *file){
     utox_update_user_file(file);
 }
 
-static int utox_file_alloc_resume(Tox *tox, FILE_TRANSFER *file){
-    TOX_ERR_FILE_GET error;
-    int i = 0;
-    int resume = 0;
-    resume = tox_file_get_file_id(tox, file->friend_number, file->file_number, file->file_id, &error);
-    if (resume){
-        file->resume = 0;
-        for(i = 1; i < MAX_FILE_TRANSFERS; i++){
-            if(!broken_list[i].used){
-                // TODO set an expire time for this.
-                broken_list[i].used = 1;
-                broken_list[i].incoming = file->incoming;
-
-                broken_list[i].friend_number = file->friend_number;
-                broken_list[i].file_number = file->file_number;
-                memcpy(broken_list[i].file_id, file->file_id, sizeof(uint8_t) * TOX_FILE_ID_LENGTH);
-                if(file->path){
-                    memcpy(broken_list[i].file_path, file->path, file->path_length);
-                }
-
-                FILE_TRANSFER *data = malloc(sizeof(FILE_TRANSFER));
-                memcpy(data, file, sizeof(FILE_TRANSFER));
-                broken_list[i].data = data;
-                break;
-            }
-        }
-        if(i >= 1 && i <= MAX_FILE_TRANSFERS){
-            debug("FileTransfer:\tBroken transfer #%u set; ready to resume file %.*s\n", i, (uint32_t)file->name_length, file->name);
-            return i;
-        } else {
-            debug("FileTransfer:\tUnable to set resume number; number was %i, name was %.*s\n", i, (uint32_t)file->name_length, file->name);
-            return 0;
-        }
-    } else {
-        debug("FileTransfer:\tUnable to get file id for incoming file... uTox can't resume file %.*s\n", (uint32_t)file->name_length, file->name);
+static int utox_file_alloc_ftinfo(FILE_TRANSFER *file){
+    uint8_t blank_id[TOX_FILE_ID_LENGTH] = {0};
+    if(memcmp(file->file_id, blank_id, TOX_FILE_ID_LENGTH) == 0){
+        debug("FileTransfer:\tUnable to get file id from tox... uTox can't resume file %.*s\n", (uint32_t)file->name_length, file->name);
         return 0;
     }
+
+    uint8_t path[UTOX_FILE_NAME_LENGTH];
+    size_t path_length;
+    path_length = datapath(path);
+    uint8_t hex_id[TOX_FILE_ID_LENGTH * 2];
+    fid_to_string(hex_id, file->file_id);
+    memcpy((path + path_length), hex_id, TOX_FILE_ID_LENGTH * 2);
+    strcpy((char*)(path + (path_length + TOX_FILE_ID_LENGTH * 2)), ".ftinfo");
+
+    FILE *saveinfo = fopen((const char*)path, "wb");
+    if(!file) {
+        debug("FileTransfer:\tUnable to save file info... uTox can't resume file %.*s\n", (uint32_t)file->name_length, file->name);
+        return 0;
+    }
+    file->saveinfo = saveinfo;
+    debug("FileTransfer:\t.ftinfo for file %.*s set; ready to resume!", (uint32_t)file->name_length, file->name);
+    return 1;
 }
 
-static void utox_file_free_resume(uint8_t i){
-    if(i >= 1 && i < MAX_FILE_TRANSFERS){
-        memset(&broken_list[i], 0, sizeof(BROKEN_TRANSFER));
-        // TODO recurse and free needed allocs
-        debug("FileTransfer:\tBroken transfer #%u reset!\n",i);
-        return;
+static void utox_file_free_ftinfo(FILE_TRANSFER *file){
+    if(file->saveinfo){
+        uint8_t path[UTOX_FILE_NAME_LENGTH];
+        size_t path_length;
+        path_length = datapath(path);
+        uint8_t hex_id[TOX_FILE_ID_LENGTH * 2];
+        fid_to_string(hex_id, file->file_id);
+        memcpy((path + path_length), hex_id, TOX_FILE_ID_LENGTH * 2);
+        strcpy((char*)(path + (path_length + TOX_FILE_ID_LENGTH * 2)), ".ftinfo");
+        remove((const char*)path);
     }
-    if ( i != 0 || broken_list[i].used) { // We shouldn't be called for a 0; but either way no error needed!
-        debug("FileTransfer:\tBroken transfer #%u unable to be reset! This is bad!\n",i);
-    }
-}
-
-static void utox_build_file_transfer(FILE_TRANSFER *ft, uint32_t friend_number, uint32_t file_number,
-    uint64_t file_size, _Bool incoming, _Bool in_memory, _Bool is_avatar, uint8_t kind, const uint8_t *name,
-    size_t name_length, const uint8_t *path, size_t path_length, const uint8_t *file_id, Tox *tox);
-
-static FILE_TRANSFER* utox_file_find_existing(uint8_t *file_id){
-    if(!file_id){
-        return NULL;
-    }
-    for(int i = 1; i < MAX_FILE_TRANSFERS; i++){
-        if(broken_list[i].used && memcmp(broken_list[i].file_id, file_id, TOX_FILE_ID_LENGTH) == 0){
-            if(broken_list[i].data){
-                debug("FileTransfer:\tExisting found, list number %u\n", i);
-                return broken_list[i].data;
-            } else {
-                debug("FileTransfer:\tExisting found (post-restart), list number %u\n", i);
-
-                FILE_TRANSFER *tmp = malloc(sizeof(*tmp));
-
-                utox_build_file_transfer(tmp, broken_list[i].friend_number, broken_list[i].file_number, 0,
-                    broken_list[i].incoming, 0, 0, 3, NULL, 0, broken_list[i].file_path,
-                    strlen((const char*)broken_list[i].file_path), broken_list[i].file_id, NULL);
-                tmp->resume = i;
-                debug("path:: %s\n", tmp->path);
-                return tmp;
-            }
-        }
-    }
-    return NULL;
 }
 
 static void utox_kill_file(FILE_TRANSFER *file, uint8_t us){
@@ -159,8 +115,8 @@ static void utox_kill_file(FILE_TRANSFER *file, uint8_t us){
         --friend[file->friend_number].transfer_count;
     }
     utox_cleanup_file_transfers(file->friend_number, file->file_number);
-    utox_file_free_resume(file->resume);
-    utox_file_save_active();
+    utox_file_free_ftinfo(file);
+    utox_file_save_ftinfo(file);
 }
 
 static void utox_break_file(FILE_TRANSFER *file){
@@ -303,37 +259,25 @@ static void utox_complete_file(FILE_TRANSFER *file){
     } else {
         debug("FileTransfer:\tUnable to complete file in non-active state (file:%u)\n", file->file_number);
     }
-    utox_file_free_resume(file->resume);
+    utox_file_free_ftinfo(file);
     utox_cleanup_file_transfers(file->friend_number, file->file_number);
-    utox_file_save_active();
+    utox_file_save_ftinfo(file);
     file->resume = 0; // We don't need to always be resetting this broken number anymore
-}
-
-static void utox_restart_file(Tox *tox, BROKEN_TRANSFER broken, uint8_t broken_number){
-    debug("FileTransfer:\tRestarting File\n");
-    if(broken.data){
-        outgoing_file_send_existing(tox, broken.data, broken_number);
-    } else {
-        debug("FileTransfer:\tWe are post-restart, rebuilding file from %u!\n", broken_number);
-
-        FILE_TRANSFER *tmp = malloc(sizeof(*tmp));
-
-        utox_build_file_transfer(tmp, broken.friend_number, broken.file_number, 0, 0, 0, 0, 3, NULL, 0,
-            broken.file_path, strlen((const char*)broken.file_path), broken.file_id, NULL);
-        tmp->resume = broken_number;
-        debug("path:: %s\n", tmp->path);
-        outgoing_file_send_existing(tox, tmp, broken_number);
-    }
 }
 
 void ft_friend_online(Tox *tox, uint32_t friend_number){
     for(int i = 1; i < MAX_FILE_TRANSFERS; i++){
-        if( broken_list[i].used &&
-            broken_list[i].friend_number == friend_number &&
-            broken_list[i].incoming == 0){
-            utox_restart_file(tox, broken_list[i], i);
+        FILE_TRANSFER *file = &outgoing_transfer[friend_number][i];
+
+        if(file->status > FILE_TRANSFER_STATUS_NONE && file->status < FILE_TRANSFER_STATUS_COMPLETED){
+            if(file->path){
+                /* Hack because sometimes this is true when it shouldn't be TODO find out why! */
+                outgoing_file_send_existing(tox, friend_number, i);
+                return;
+            }
         }
     }
+    /* Else look in filetransfer info dir; */
 }
 
 void ft_friend_offline(Tox *tox, uint32_t friend_number){
@@ -509,94 +453,117 @@ static void incoming_file_avatar(Tox *tox, uint32_t friend_number, uint32_t file
 }
 
 static void incoming_file_existing(Tox *tox, uint32_t friend_number, uint32_t file_number, uint32_t kind, uint64_t size, const uint8_t *filename, size_t filename_length, void *UNUSED(user_data)){
-    //new incoming file
     debug("FileTransfer:\tIncoming Existing file from friend (%u) \n", friend_number);
 
-    uint8_t new_id[TOX_FILE_ID_LENGTH] = {0};
-    tox_file_get_file_id(tox, friend_number, file_number, new_id, 0);
-    FILE_TRANSFER *file_new = get_file_transfer(friend_number, file_number);
-    FILE_TRANSFER *file_existing = utox_file_find_existing(new_id);
-
-    FILE *file;
-    TOX_ERR_FILE_SEEK error = 0;
-
-    if (!file_new) {
+    FILE_TRANSFER *file_handle = get_file_transfer(friend_number, file_number);
+    if (!file_handle) {
         tox_file_control(tox, friend_number, file_number, TOX_FILE_CONTROL_CANCEL, 0);
         return;
     }
 
-    if(file_existing){
-        uint8_t old_broken_number = file_existing->resume;
-        if( file_existing->friend_number == friend_number &&
-            file_existing->size == size &&
-            memcmp(file_existing->name, filename, filename_length) == 0 ){
-            // DO STUFF
-
-            utox_build_file_transfer(file_new, friend_number, file_number, size, 1, 0, 0, TOX_FILE_KIND_EXISTING,
-                filename, filename_length, NULL, 0, new_id, tox);
-
-            file_new->size_transferred = file_existing->size_transferred;
-            file_new->file = file_existing->file;
-            file_new->ui_data = file_existing->ui_data;
-            utox_file_free_resume(old_broken_number);
-            file_new->resume = utox_file_alloc_resume(tox, file_new);
-
-            tox_file_seek(tox, friend_number, file_number, file_existing->size_transferred, &error);
-            if(error){
-                debug("FileTransfer:\tError seeking new file.");
-            }
-            file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_RESUME);
+    uint8_t file_id[TOX_FILE_ID_LENGTH];
+    tox_file_get_file_id(tox, friend_number, file_number, file_id, 0);
+    if(memcmp(file_handle->file_id, file_id, TOX_FILE_ID_LENGTH) == 0){
+        if(file_handle->size != size){
+            debug("FileTransfer:\tResume size mismatch, aborting!\n");
+            file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_CANCEL);
+            return;
         } else {
-            debug("FileTransfer:\tSomething didn't match, does that file still exist?\n");
-            file_new->path = file_existing->path;
-            file = fopen((char*)broken_list[old_broken_number].file_path, "rb");
-            uint64_t file_size = 0;
-            if(file){
-                debug("FileTransfer:\tCool file exists, let try to restart it.\n");
-                fseeko(file, 0, SEEK_END);
-                file_size = ftello(file);
-                fseeko(file, 0, SEEK_SET);
-                fclose(file);
-                if(file_size >= size){
-                    // This is a case we don't want to touch... Just abort.
-                    debug("FileTransfer:\tResume size mismatch, aborting!");
-                } else {
-                    file = fopen((const char*)file_new->path, "ab");
-                    if(file){
-                        utox_build_file_transfer(file_new, friend_number, file_number, size, 1, 0, 0,
-                            TOX_FILE_KIND_DATA, filename, filename_length, file_new->path, file_existing->path_length, new_id, tox);
-
-                        file_new->file = file;
-                        file_new->size_transferred = file_size;
-                        file_new->ui_data = message_add_type_file(file_new);
-                        file_new->resume = utox_file_alloc_resume(tox, file_new);
-                        debug("Resume %i\n", file_new->resume);
-
-                        tox_file_seek(tox, friend_number, file_number, file_new->size_transferred, &error);
-                        postmessage(FRIEND_FILE_NEW, 0, 0, file_new);
-                        file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_RESUME);
-                    } else {
-                        debug("FileTransfer:\tFile opened for reading, but unable to write.\n");
-                        file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_CANCEL);
-                    }
-                }
-            } else {
-                debug("FileTransfer:\tUnable to open that file; treating as new.\n");
-                utox_build_file_transfer(file_new, friend_number, file_number, size, 1, 0, 0, TOX_FILE_KIND_DATA,
-                    filename, filename_length, NULL, 0, new_id, tox);
-
-                file_new->ui_data = message_add_type_file(file_new);
-                file_new->resume = utox_file_alloc_resume(tox, file_new);
-
-                postmessage(FRIEND_FILE_NEW, 0, 0, file_new);
+            debug("FileTransfer:\tIncoming existing file approved!\n");
+            tox_file_seek(tox, friend_number, file_number, file_handle->size_transferred, 0);
+            file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_RESUME);
+            return;
+        }
+    } else {
+        /* File number wasn't the same, maybe it's still somewhere? */
+        int good = 0; /* Used to skip searching for files */
+        FILE_TRANSFER *file_search;
+        for(int i = 0 ; i < MAX_FILE_TRANSFERS ; i++){
+            file_search = get_file_transfer(friend_number, i);
+            if(memcmp(file_search->file_id, file_id, TOX_FILE_ID_LENGTH) == 0){
+                memcpy(file_handle, file_search, sizeof(*file_handle));
+                file_handle->file_number = file_number;
+                break;
             }
-            utox_file_free_resume(old_broken_number);
+        }
+        if(good){
+            /* Found with a different number */
+            debug("FileTransfer:\tResume file found, number changed!\n");
+            if(file_handle->size != size){
+                debug("FileTransfer:\tResume size mismatch, aborting!\n");
+                file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_CANCEL);
+                return;
+            } else {
+                debug("FileTransfer:\tIncoming existing file approved!\n");
+                tox_file_seek(tox, friend_number, file_number, file_handle->size_transferred, 0);
+                file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_RESUME);
+                return;
+            }
+        }
+    }
+
+    /* File is not in memory, we must have lost the connection, search files. */
+    file_handle->friend_number = friend_number;
+    file_handle->file_number   = file_number;
+    memcpy(file_handle->file_id, file_id, TOX_FILE_ID_LENGTH);
+    utox_file_load_ftinfo(file_handle);
+    if(file_handle->status){
+        /* We found the save info for this file, let's rebuild! */
+        FILE *file = fopen((const char*)file_handle->path, "rb");
+        uint64_t file_size = 0;
+        if(file){
+            debug("FileTransfer:\tCool file exists, let try to restart it.\n");
+            fseeko(file, 0, SEEK_END);
+            file_size = ftello(file);
+            fseeko(file, 0, SEEK_SET);
+            fclose(file);
+            if(file_size != size){
+                debug("FileTransfer:\tIncoming size, and size on disk mismatch, aborting!\n");
+                file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_CANCEL);
+                return;
+            }
+            file = fopen((const char*)file_handle->path, "ab");
+            if(file){
+                utox_build_file_transfer(file_handle, friend_number, file_number, size, 1, 0, 0,
+                    TOX_FILE_KIND_DATA, filename, filename_length, file_handle->path, file_handle->path_length,
+                    file_handle->file_id, tox);
+
+                file_handle->file = file;
+                file_handle->ui_data = message_add_type_file(file_handle);
+                file_handle->resume = utox_file_alloc_ftinfo(file_handle);
+                tox_file_seek(tox, friend_number, file_number, file_handle->size_transferred, 0);
+                postmessage(FRIEND_FILE_NEW, 0, 0, file_handle);
+                file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_RESUME);
+            } else {
+                debug("FileTransfer:\tFile opened for reading, but unable to write.\n");
+                file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_CANCEL);
+            }
+        } else {
+            debug("FileTransfer:\tUnable to open that file; treating as new.\n");
+            utox_build_file_transfer(file_handle, friend_number, file_number, size, 1, 0, 0, TOX_FILE_KIND_DATA,
+                filename, filename_length, NULL, 0, file_id, tox);
+
+            file_handle->ui_data = message_add_type_file(file_handle);
+            file_handle->resume = utox_file_alloc_ftinfo(file_handle);
+            postmessage(FRIEND_FILE_NEW, 0, 0, file_handle);
+        }
+
+        if(file_handle->size != size){
+            debug("FileTransfer:\tResume size mismatch, aborting!\n");
+            file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_CANCEL);
+            return;
+        } else {
+            debug("FileTransfer:\tIncoming existing file approved!\n");
+            tox_file_seek(tox, friend_number, file_number, file_handle->size_transferred, 0);
+            file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_RESUME);
+            return;
         }
     } else {
         debug("FileTransfer:\tWe don't know anything about this file, so for safety we're just going to reject it!.\n");
         file_transfer_local_control(tox, friend_number, file_number, TOX_FILE_CONTROL_CANCEL);
     }
 }
+
 /* Function called by core with a new incoming file. */
 static void incoming_file_callback_request(Tox *tox, uint32_t friend_number, uint32_t file_number, uint32_t kind, uint64_t file_size, const uint8_t *filename, size_t filename_length, void *user_data){
 
@@ -629,7 +596,7 @@ static void incoming_file_callback_request(Tox *tox, uint32_t friend_number, uin
                                 filename, filename_length, NULL, 0, NULL, tox);
 
         file_handle->ui_data = message_add_type_file(file_handle);
-        file_handle->resume = utox_file_alloc_resume(tox, file_handle);
+        file_handle->resume = utox_file_alloc_ftinfo(file_handle);
 
         postmessage(FRIEND_FILE_NEW, 0, 0, file_handle);
     }
@@ -686,10 +653,7 @@ static void incoming_file_callback_chunk(Tox *UNUSED(tox), uint32_t friend_numbe
     }
     file_handle->size_transferred += length;
     // TODO dirty hack, this needs to be replaced
-    if(file_handle->resume){
-        broken_list[file_handle->resume].data->size_transferred = file_handle->size_transferred;
-        broken_list[file_handle->resume].data->file = file_handle->file;
-    }
+    utox_file_save_ftinfo(file_handle);
 
     calculate_speed(file_handle);
 }
@@ -734,7 +698,7 @@ void outgoing_file_send_new(Tox *tox, uint32_t friend_number, uint8_t *path, con
         }
 
         file_handle->ui_data = message_add_type_file(file_handle);
-        file_handle->resume = utox_file_alloc_resume(tox, file_handle);
+        file_handle->resume = utox_file_alloc_ftinfo(file_handle);
 
         // TODO move this to utox_file_run(ish)
         ++friend[friend_number].transfer_count;
@@ -748,36 +712,36 @@ void outgoing_file_send_new(Tox *tox, uint32_t friend_number, uint8_t *path, con
     }
 }
 
-void outgoing_file_send_existing(Tox *tox, FILE_TRANSFER *broken_data, uint8_t broken_number){
-    debug("FileTransfer:\tRestarting outgoing file to friend %u. (filename, %s)\n", broken_data->friend_number, broken_data->path);
+void outgoing_file_send_existing(Tox *tox, uint32_t friend_number, uint32_t file_number){
+    FILE_TRANSFER *file_handle = get_file_transfer(friend_number, file_number);
+    debug("FileTransfer:\tRestarting outgoing file to friend %u. (filename, %s)\n", file_handle->friend_number, file_handle->path);
 
-    if(friend[broken_data->friend_number].transfer_count >= MAX_FILE_TRANSFERS) {
+    if(friend[file_handle->friend_number].transfer_count >= MAX_FILE_TRANSFERS) {
         debug("FileTransfer:\tMaximum outgoing file sending limit reached(%u/%u) for friend(%u). ABORTING!\n",
-            friend[broken_data->friend_number].transfer_count, MAX_FILE_TRANSFERS, broken_data->friend_number);
-        utox_file_free_resume(broken_data->resume);
+            friend[file_handle->friend_number].transfer_count, MAX_FILE_TRANSFERS, file_handle->friend_number);
         return;
     }
 
-    if(!broken_data->file) {
+    if(!file_handle->file) {
         debug("FileTransfer:\tUnable to open file for reading, trying to re-access!\n");
-        if(broken_data->path_length){
-            FILE *file = fopen((const char*)broken_data->path, "rb");
+        if(file_handle->path_length){
+            FILE *file = fopen((const char*)file_handle->path, "rb");
             if(file){
-                broken_data->file = file;
+                file_handle->file = file;
                 fseeko(file, 0, SEEK_END);
-                broken_data->size = ftello(file);
+                file_handle->size = ftello(file);
                 fseeko(file, 0, SEEK_SET);
             } else {
                 debug("FileTransfer:\tUnable to re-access file, must fail!\n");
-                file_transfer_local_control(tox, broken_data->friend_number, broken_data->file_number, TOX_FILE_CONTROL_CANCEL);
+                file_transfer_local_control(tox, file_handle->friend_number, file_handle->file_number, TOX_FILE_CONTROL_CANCEL);
                 return;
             }
         }
     }
 
     TOX_ERR_FILE_SEND error;
-    const uint8_t *file_id = broken_data->file_id;
-    uint8_t *p = broken_data->path, *name = broken_data->path;
+    const uint8_t *file_id = file_handle->file_id;
+    uint8_t *p = file_handle->path, *name = file_handle->path;
     while(*p != '\0') {
         if(*p == '/' || *p == '\\') {
             name = p + 1;
@@ -785,28 +749,26 @@ void outgoing_file_send_existing(Tox *tox, FILE_TRANSFER *broken_data, uint8_t b
         p++;
     }
 
-    int new_file_number = tox_file_send(tox, broken_data->friend_number, TOX_FILE_KIND_EXISTING, broken_data->size, file_id, name, p - name, &error);
+    int new_file_number = tox_file_send(tox, file_handle->friend_number, TOX_FILE_KIND_EXISTING, file_handle->size, file_id, name, p - name, &error);
     if(new_file_number != -1) {
-        FILE_TRANSFER *file_handle = get_file_transfer(broken_data->friend_number, new_file_number);
+        FILE_TRANSFER *file_handle_new = get_file_transfer(file_handle->friend_number, new_file_number);
 
-        utox_build_file_transfer(file_handle, broken_data->friend_number, new_file_number, broken_data->size, 0, 0, 0,
-            TOX_FILE_KIND_EXISTING, name, p - name, broken_data->path, broken_data->path_length, file_id, tox);
+        utox_build_file_transfer(file_handle_new, friend_number, new_file_number, file_handle->size, 0, 0, 0,
+            TOX_FILE_KIND_EXISTING, name, p - name, file_handle->path, file_handle->path_length, file_id, tox);
 
-        file_handle->file = broken_data->file;
-        if(broken_data->ui_data){
-            file_handle->ui_data = broken_data->ui_data;
+        file_handle_new->file = file_handle->file;
+        if(file_handle->ui_data){
+            file_handle_new->ui_data = file_handle->ui_data;
         } else {
-            file_handle->ui_data = message_add_type_file(file_handle);
+            file_handle_new->ui_data = message_add_type_file(file_handle_new);
         }
-        utox_file_free_resume(broken_number);
-        file_handle->resume = utox_file_alloc_resume(tox, file_handle);
-        ++friend[file_handle->friend_number].transfer_count;
-        debug("Resending file %d of %d(max) to friend(%d).\n", friend[file_handle->friend_number].transfer_count, MAX_FILE_TRANSFERS, file_handle->friend_number);
-        utox_update_user_file(file_handle);
+        file_handle_new->resume = utox_file_alloc_ftinfo(file_handle_new);
+        ++friend[friend_number].transfer_count;
+        debug("Resending file %d of %d(max) to friend(%d).\n", friend[friend_number].transfer_count, MAX_FILE_TRANSFERS, friend_number);
+        utox_update_user_file(file_handle_new);
     } else {
         debug("tox_file_send() failed\n");
     }
-    free(broken_data);
 }
 
 void outgoing_file_send_inline(Tox *tox, uint32_t friend_number, uint8_t *image, size_t image_size){
@@ -980,12 +942,21 @@ int utox_file_start_write(uint32_t friend_number, uint32_t file_number, void *fi
     if(!file_handle->file) {
         debug("FileTransfer:\tThe file we're supposed to write to couldn't be opened\n");
         free(filepath);
-        file_handle->status = FILE_TRANSFER_STATUS_BROKEN;
+        utox_break_file(file_handle);
         return -1;
     }
+    if(resize_file(file_handle->file, file_handle->size) != 0){
+        debug("FileTransfer:\tThe file size was unable to be changed!\n");
+        free(filepath);
+        fclose(file_handle->file);
+        utox_break_file(file_handle);
+        remove(filepath);
+        return -1;
+    }
+
     file_handle->path = filepath;
     file_handle->path_length = strlen(filepath);
-    memcpy(broken_list[file_handle->resume].file_path, file_handle->path, file_handle->path_length);
+    free(filepath);
             // Removed until we can find a better way of working this in;
             // if(file_handle->in_tmp_loc){
             //     fseeko(file_handle->tmp_file, 0, SEEK_SET);
@@ -1021,7 +992,7 @@ int utox_file_start_temp_write(uint32_t friend_number, uint32_t file_number){/*
     file_handle->in_tmp_loc = 1;
     file_handle->tmp_path = path;
     file_handle->tmp_path_length = strlen((const char*)path);
-*/
+    */
     return 0;
 }
 
@@ -1053,42 +1024,47 @@ void utox_cleanup_file_transfers(uint32_t friend_number, uint32_t file_number){
     }
 }
 
-void utox_file_save_active(void){
-    uint8_t path[UTOX_FILE_NAME_LENGTH], *p;
-    FILE *file;
+void utox_file_save_ftinfo(FILE_TRANSFER *file){
+    if(!file->saveinfo){
+        return;
+    }
+    fwrite(file, sizeof(*file), 1, file->saveinfo);
+    fwrite("\0\0", sizeof(uint8_t), 2, file->saveinfo);
+    fwrite(file->path, sizeof(uint8_t), file->path_length, file->saveinfo);
+    fwrite("\0", sizeof(char_t), 1, file->saveinfo);
+    fflush(file->saveinfo);
+    fseeko(file->saveinfo, 0, SEEK_SET);
+}
 
-    p = path + datapath(path);
-    strcpy((char*)p, "utox_files.data");
+void utox_file_load_ftinfo(FILE_TRANSFER *file){
+    uint8_t path[UTOX_FILE_NAME_LENGTH];
+    size_t path_length;
+    uint32_t size_read;
 
-    file = fopen((char*)path, "wb");
-    if(!file) {
-        debug("SaveFile:\tUnable to open uTox Save file for File Transfers\n");
+    path_length = datapath(path);
+    uint8_t hex_id[TOX_FILE_ID_LENGTH * 2];
+    fid_to_string(hex_id, file->file_id);
+    memcpy((path + path_length), hex_id, TOX_FILE_ID_LENGTH * 2);
+    strcpy((char*)(path + (path_length + TOX_FILE_ID_LENGTH * 2)), ".ftinfo");
+
+    void *load = file_raw((char*)path, &size_read);
+
+    if(!load) {
+        debug("FileTransfer:\tUnable to load saved info... uTox can't resume file %.*s\n", (uint32_t)file->name_length, file->name);
+        file->status = 0;
         return;
     }
 
-    debug("SaveFile:\tWriting uTox Save file for File Transfers \n");
-    fwrite(broken_list, (sizeof(BROKEN_TRANSFER) * MAX_FILE_TRANSFERS), 1, file);
-    fclose(file);
+    FILE_TRANSFER *info = malloc(sizeof(*info));
+    memcpy(info, load, sizeof(*info));
+    info->path_length = (size_read - sizeof(*info) - 2 /* padding */ - 1 /* NULL Term */ );
+    info->path = malloc(info->path_length + 1);
+    memcpy(info->path, load + (sizeof(*info) + (sizeof(char_t) * 2)), info->path_length + 1);
 
-}
+    info->friend_number = file->friend_number;
+    info->file_number   = file->file_number;
+    info->saveinfo = fopen((const char*)path, "wb");
 
-void utox_file_load_active(void){
-    uint8_t path[UTOX_FILE_NAME_LENGTH], *p;
-    uint32_t size_read;
-
-    p = path + datapath(path);
-    strcpy((char*)p, "utox_files.data");
-
-    BROKEN_TRANSFER *saved = calloc(MAX_FILE_TRANSFERS, sizeof(BROKEN_TRANSFER));
-    saved = file_raw((char*)path, &size_read);
-    if(saved && size_read == (sizeof(BROKEN_TRANSFER) * MAX_FILE_TRANSFERS)){
-        memcpy(broken_list, saved, (sizeof(BROKEN_TRANSFER) * MAX_FILE_TRANSFERS));
-    } else {
-        debug("SaveFile:\tUnable to load uTox Save file for File Transfers\n");
-    }
-    free(saved);
-
-    for(int i = 0 ; i < MAX_FILE_TRANSFERS ; i++){
-        broken_list[i].data = NULL;
-    }
+    memcpy(file, info, sizeof(*file));
+    return;
 }

--- a/file_transfers.h
+++ b/file_transfers.h
@@ -1,7 +1,5 @@
 #define MAX_FILE_TRANSFERS 32
 
-#define FILE_TRANSFER_TEMP_PATH "transfers"
-
 enum UTOX_FILE_TRANSFER_STATUS{
     FILE_TRANSFER_STATUS_NONE,
     FILE_TRANSFER_STATUS_ACTIVE,
@@ -27,18 +25,9 @@ typedef struct FILE_TRANSFER {
     uint32_t speed, num_packets;
     uint64_t last_check_time, last_check_transferred;
 
-    FILE *file; //, *tmp_file;
+    FILE *file, *saveinfo;
     MSG_FILE *ui_data;
 } FILE_TRANSFER;
-
-typedef struct {
-    _Bool used, incoming;
-    uint32_t friend_number, file_number;
-    uint8_t file_id[TOX_FILE_ID_LENGTH];
-    uint8_t file_path[UTOX_FILE_NAME_LENGTH];
-
-    FILE_TRANSFER *data;
-} BROKEN_TRANSFER;
 
 /** local callback for file transfers
  *
@@ -59,11 +48,12 @@ void file_transfer_local_control(Tox *tox, uint32_t friend_number, uint32_t file
   /* Function called by core with a new incoming file. */
   //static void incoming_file_callback_request(Tox *tox, uint32_t friendnumber, uint32_t filenumber, uint32_t kind, uint64_t file_size, const uint8_t *filename, size_t filename_length, void *user_data);
   //static void incoming_file_callback_chunk(Tox *tox, uint32_t friend_number, uint32_t file_number, uint64_t position, const uint8_t *data, size_t length, void *user_data);
+
 /* Outgoing files */
   /* Send out a new file. */
   void outgoing_file_send_new(Tox *tox, uint32_t friend_number, uint8_t *path, const uint8_t *filename, size_t filename_length);
   /* Restarts a broken file. */
-  void outgoing_file_send_existing(Tox *tox, FILE_TRANSFER *broken_data, uint8_t broken_number);
+  void outgoing_file_send_existing(Tox *tox, uint32_t friend_number, uint32_t file_number);
   /* Send an inline file/image. */
   void outgoing_file_send_inline(Tox *tox, uint32_t friend_number, uint8_t *image, size_t image_size);
   /* Send a newly changed avatar, called by avatar functions. */
@@ -89,5 +79,5 @@ void ft_friend_offline(Tox *tox, uint32_t friend_number);
 
 /** Functions called to store/load broken_list
  */
-void utox_file_save_active(void);
-void utox_file_load_active(void);
+void utox_file_save_ftinfo(FILE_TRANSFER *file);
+void utox_file_load_ftinfo(FILE_TRANSFER *file);

--- a/main.h
+++ b/main.h
@@ -342,6 +342,7 @@ int datapath_old(uint8_t *dest);
 int datapath(uint8_t *dest);
 int datapath_subdir(uint8_t *dest, const char *subdir);
 void flush_file(FILE *file);
+int resize_file(FILE *file, uint64_t size);
 int ch_mod(uint8_t *file);
 int file_lock(FILE *file, uint64_t start, size_t length);
 int file_unlock(FILE *file, uint64_t start, size_t length);

--- a/tox.c
+++ b/tox.c
@@ -562,9 +562,6 @@ void tox_thread(void *UNUSED(args))
             load_defaults(tox);
         }
 
-        // Load saved file transfers
-        utox_file_load_active();
-
         // Set local info for self
         edit_setstr(&edit_name, self.name, self.name_length);
         edit_setstr(&edit_status, self.statusmsg, self.statusmsg_length);
@@ -638,8 +635,6 @@ void tox_thread(void *UNUSED(args))
                 if (save_needed || (time - last_save >= (uint64_t)100 * 1000 * 1000 * 1000)){
                     // Save tox data
                     write_save(tox);
-                    // Save file transfer data
-                    utox_file_save_active();
                 }
             }
 

--- a/tox.c
+++ b/tox.c
@@ -1127,6 +1127,7 @@ static void tox_thread_message(Tox *tox, ToxAv *av, uint64_t time, uint8_t msg, 
         } else {
             ft_friend_online(tox, param1);
             /* resend avatar info (in case it changed) */
+            /* Avatars must be sent LAST or they will clobber existing file transfers! */
             avatar_on_friend_online(tox, param1);
         }
         break;

--- a/tox.c
+++ b/tox.c
@@ -1096,6 +1096,7 @@ static void tox_thread_message(Tox *tox, ToxAv *av, uint64_t time, uint8_t msg, 
             file_transfer_local_control(tox, param1, param2, TOX_FILE_CONTROL_CANCEL);
         }
         break;
+        free(data);
     }
 
     case TOX_FILE_INCOMING_RESUME:
@@ -1619,7 +1620,6 @@ void tox_message(uint8_t tox_message_id, uint16_t param1, uint16_t param2, void 
         }
 
         updatefriend(f);
-        // todo free
         free(file);
         break;
     }

--- a/util.c
+++ b/util.c
@@ -120,18 +120,19 @@ static void to_hex(char_t *a, char_t *p, int size)
     }
 }
 
-void id_to_string(char_t *dest, char_t *src)
-{
+void id_to_string(char_t *dest, char_t *src){
     to_hex(dest, src, TOX_FRIEND_ADDRESS_SIZE);
 }
 
-void cid_to_string(char_t *dest, char_t *src)
-{
+void cid_to_string(char_t *dest, char_t *src){
     to_hex(dest, src, TOX_PUBLIC_KEY_SIZE);
 }
 
-void hash_to_string(char_t *dest, char_t *src)
-{
+void fid_to_string(char_t *dest, char_t *src){
+    to_hex(dest, src, TOX_FILE_ID_LENGTH);
+}
+
+void hash_to_string(char_t *dest, char_t *src){
     to_hex(dest, src, TOX_HASH_LENGTH);
 }
 

--- a/util.h
+++ b/util.h
@@ -21,7 +21,12 @@ void id_to_string(char_t *dest, char_t *src);
  */
 void cid_to_string(char_t *dest, char_t *src);
 
-/* convert tox hash to string, 
+
+/* same as id_to_string(), but for TOX_FILE_ID_LENGTH
+ */
+void fid_to_string(char_t *dest, char_t *src);
+
+/* convert tox hash to string,
  *  notes: dest must be (TOX_HASH_LENGTH * 2) bytes large, src must be TOX_HASH_LENGTH bytes large
  */
 void hash_to_string(char_t *dest, char_t *src);

--- a/win32/main.c
+++ b/win32/main.c
@@ -947,6 +947,10 @@ void flush_file(FILE *file)
     _commit(fd);
 }
 
+int resize_file(FILE *file, uint64_t size){
+    return _ch_size(file, size);
+}
+
 
 int ch_mod(uint8_t *file){
     /* You're probably looking for ./xlib as windows is lamesauce and wants nothing to do with sane permissions */

--- a/win32/main.c
+++ b/win32/main.c
@@ -41,6 +41,13 @@ extern const CLSID CLSID_NullRenderer;
 #include <shlobj.h>
 
 #include <io.h>
+#include <error.h>
+
+/* mingw64 doesn't provide this def, but it should exist... */
+errno_t _chsize_s(
+   int fd,
+   __int64 size
+);
 
 #undef CLEARTYPE_QUALITY
 #define CLEARTYPE_QUALITY 5
@@ -948,7 +955,7 @@ void flush_file(FILE *file)
 }
 
 int resize_file(FILE *file, uint64_t size){
-    return _ch_size(file, size);
+    return _chsize_s(fileno(file), size);
 }
 
 

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -17,6 +17,7 @@
 #include <X11/extensions/XShm.h>
 #include <sys/shm.h>
 
+#define _GNU_SOURCE
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
@@ -752,6 +753,11 @@ void flush_file(FILE *file)
     int fd = fileno(file);
     fsync(fd);
 }
+
+int resize_file(FILE *file, uint64_t size){
+    return posix_fallocate(fileno(file), 0, size);
+}
+
 
 void setscale(void)
 {


### PR DESCRIPTION
There was a risk of a friend being able to start a file to us, have us accept the file. Then if the friend was to go disconnect, and wait for our client to restart. That friend would be able to send a file of an arbitrary length, and we would accept it without question.

Additionally, there was a max limit of 32 resumable transfers, for all friends combined. Now the only limit is the of the max concurrent transfers PER friend. So that one friend won't interfere with a different friends transfers.

Finally; previously, there was a risk of data leakage as outgoing transfers only searched by friend number. If any lower number friend was removed from the list, or the original friend was removed. uTox would try to resume a file to which ever friend took that friends spot. Now if a friend number is changed, uTox will only resume a file if the pubkey matches for that friend, regardless of the number. Small caveat, if you remove that friend with a pending broken transfer, the information to resume that transfer will remain on disk.

@irungentoo I've tested this and it's ready to merge.