### PR TITLE
Fixed multiple misuses of snprintf.

### DIFF
--- a/messages.c
+++ b/messages.c
@@ -100,6 +100,10 @@ void messages_draw(MESSAGES *m, int x, int y, int width, int height)
             char timestr[6];
             STRING_IDX len;
             len = snprintf(timestr, sizeof(timestr), "%u:%.2u", msg->time / 60, msg->time % 60);
+            if (len >= sizeof(timestr)) {
+                len = sizeof(timestr) - 1;
+            }
+
             setcolor(COLOR_MAIN_SUBTEXT);
             setfont(FONT_MISC);
             drawtext(x + width - TIME_WIDTH, y, (char_t*)timestr, len);
@@ -240,6 +244,9 @@ void messages_draw(MESSAGES *m, int x, int y, int width, int height)
 
             char_t text2[16];
             STRING_IDX len2 = snprintf((char*)text2, sizeof(text2), "%us", (uint32_t)etasec);
+            if (len2 >= sizeof(text2)) {
+                len2 = sizeof(text2) - 1;
+            }
 
             // progress rectangle
             uint32_t w = (file->size == 0) ? 0 : (progress * (uint64_t)106 * SCALE) / file->size;

--- a/tox.c
+++ b/tox.c
@@ -1633,6 +1633,9 @@ void tox_message(uint8_t tox_message_id, uint16_t param1, uint16_t param2, void 
     case GROUP_ADD: {
         GROUPCHAT *g = &group[param1];
         g->name_length = snprintf((char*)g->name, sizeof(g->name), "Groupchat #%u", param1);
+        if (g->name_length >= sizeof(g->name)) {
+            g->name_length = sizeof(g->name) - 1;
+        }
         g->topic_length = sizeof("Drag friends to invite them") - 1;
         memcpy(g->topic, "Drag friends to invite them", sizeof("Drag friends to invite them") - 1);
         g->msg.scroll = 1.0;
@@ -1681,6 +1684,9 @@ void tox_message(uint8_t tox_message_id, uint16_t param1, uint16_t param2, void 
         }
 
         g->topic_length = snprintf((char*)g->topic, sizeof(g->topic), "%u users in chat", g->peers);
+        if (g->topic_length >= sizeof(g->topic)) {
+            g->topic_length = sizeof(g->topic) - 1;
+        }
 
         updategroup(g);
 
@@ -1718,6 +1724,9 @@ void tox_message(uint8_t tox_message_id, uint16_t param1, uint16_t param2, void 
         g->peername[param2] = data;
 
         g->topic_length = snprintf((char*)g->topic, sizeof(g->topic), "%u users in chat", g->peers);
+        if (g->topic_length >= sizeof(g->topic)) {
+            g->topic_length = sizeof(g->topic) - 1;
+        }
 
         updategroup(g);
 

--- a/util.c
+++ b/util.c
@@ -185,8 +185,16 @@ int sprint_bytes(uint8_t *dest, unsigned int size, uint64_t bytes)
 
     r = snprintf((char*)dest, size, "%u", (uint32_t)bytes);
 
-    //missing decimals
-    r += snprintf((char*)dest + r, size - r, "%s", str[i]);
+    if (r >= size) { // truncated
+        r = size - 1;
+    } else {
+        //missing decimals
+        r += snprintf((char*)dest + r, size - r, "%s", str[i]);
+        if (r >= size) { // truncated
+            r = size - 1;
+        }
+    }
+
     return r;
 }
 
@@ -654,6 +662,9 @@ NEXT:
     strcpy((char*)edit_proxy_ip.data, (char*)save->proxy_ip);
     if(save->proxy_port) {
         edit_proxy_port.length = snprintf((char*)edit_proxy_port.data, edit_proxy_port.maxlength + 1, "%u", save->proxy_port);
+        if (edit_proxy_port.length >= edit_proxy_port.maxlength + 1) {
+            edit_proxy_port.length = edit_proxy_port.maxlength;
+        }
     }
 
     logging_enabled = save->logging_enabled;


### PR DESCRIPTION
If the generated string is longer than the output buffer, `snprintf` will not overflow the buffer - this is usually why it is preferred to `sprintf`. It also returns the number of bytes *that would have been written*, not the number of bytes actually written.

Multiple places in uTox use `snprintf` and assume that the result is the actual number of character put into the buffer (excluding the null terminator.) This pull request fixes that.

This isn't necessarily a security issue, but it should probably be fixed anyway.

(This issue was discovered while making timestamps include seconds in my local copy - I'd added more text to the format string and forgotten to expand the array, and was confused by the extra unprintable characters showing up on the screen. This fixes that issue, though that issue was also fixed by having a large-enough array.)