### PR TITLE
Add seconds to message time display.

### DIFF
--- a/messages.c
+++ b/messages.c
@@ -97,9 +97,9 @@ void messages_draw(MESSAGES *m, int x, int y, int width, int height)
 
         // Draw timestamps
         {
-            char timestr[6];
+            char timestr[9];
             STRING_IDX len;
-            len = snprintf(timestr, sizeof(timestr), "%u:%.2u", msg->time / 60, msg->time % 60);
+            len = snprintf(timestr, sizeof(timestr), "%u:%.2u:%.2u", msg->time / 3600, (msg->time / 60) % 60, msg->time % 60);
             if (len >= sizeof(timestr)) {
                 len = sizeof(timestr) - 1;
             }
@@ -1016,7 +1016,7 @@ void message_add(MESSAGES *m, MESSAGE *msg, MSG_DATA *p)
     ti = localtime(&rawtime);
 
     // Set the time this message was recived by utox
-    msg->time = ti->tm_hour * 60 + ti->tm_min;
+    msg->time = ti->tm_hour * 3600 + ti->tm_min * 60 + ti->tm_sec;
 
     if(p->n < MAX_BACKLOG_MESSAGES) {
         p->data = realloc(p->data, (p->n + 1) * sizeof(void*));

--- a/tox.c
+++ b/tox.c
@@ -201,7 +201,7 @@ void log_read(Tox *tox, int fid)
         time_t rawtime = header.time;
         ti = localtime(&rawtime);
 
-        msg->time = ti->tm_hour * 60 + ti->tm_min;
+        msg->time = ti->tm_hour * 3600 + ti->tm_min * 60 + ti->tm_sec;
 
         m->data[m->n++] = msg;
 

--- a/ui.h
+++ b/ui.h
@@ -149,7 +149,7 @@ uint8_t SCALE;
 
 #define MESSAGES_SPACING (SCALE * 2)
 #define MESSAGES_X (55 * SCALE)
-#define TIME_WIDTH (16 * SCALE)
+#define TIME_WIDTH (24 * SCALE)
 #define NAME_OFFSET (7 * SCALE)
 
 #define MESSAGES_BOTTOM (-47 * SCALE)


### PR DESCRIPTION
This makes the time display next to messages `HH:MM:SS` instead of `HH:MM`.

I'm not certain whether or not this is wanted, but I'm using this in my copy of uTox and I don't see why it would be a bad idea. (I couldn't find any discussion about this except as a side-note in #794 - but it wasn't clear if that included in the chat view or just while copying messages.)

Thoughts?