### PR TITLE
Fixed windows build script, so now it works.

### DIFF
--- a/tools/cross-compile-windows.sh
+++ b/tools/cross-compile-windows.sh
@@ -75,9 +75,9 @@ else
 fi
 
 # Build filter_audio
-AUDIO_FILTERING_BUILD="-D AUDIO_FILTERING -I ./lib/filter_audio/ \
+AUDIO_FILTERING_BUILD="-DAUDIO_FILTERING -I ./lib/filter_audio/ \
 ./lib/filter_audio/filter_audio.c ./lib/filter_audio/aec/*.c ./lib/filter_audio/agc/*.c \
-./lib/filter_audio/ns/*.c ./lib/filter_audio/other/*.c"
+./lib/filter_audio/ns/*.c ./lib/filter_audio/other/*.c ./lib/filter_audio/zam/*.c"
 
 # Remove existing
 rm utox.exe 2> /dev/null


### PR DESCRIPTION
Fixed windows build script, so now it compiles filter audio properly.