### PR TITLE
Add --datapath option

### DIFF
--- a/cocoa/main.m
+++ b/cocoa/main.m
@@ -247,7 +247,7 @@ void ensure_directory_r(char *path, int perm) {
 /* it occured to me that we should probably make datapath allocate memory for its caller */
 int datapath(uint8_t *dest) {
     if (user_defined_datapath) {
-        int l = sprintf((char*)dest, "%.230s", user_datapath);
+        int l = sprintf((char*)dest, "%s", user_datapath);
         dest[l++] = '/';
 
         return l;

--- a/cocoa/main.m
+++ b/cocoa/main.m
@@ -4,6 +4,7 @@
 #include <sys/syslimits.h>
 #include <pthread.h>
 #include <libgen.h>
+#include <unistd.h>
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>
 
@@ -105,7 +106,7 @@ int parse_argv(int argc, char const *argv[]) {
                 if ((strlen(argv[i]) > 10) && (argv[i][10] == '=')) {
                     strncpy(user_datapath, argv[i]+11, PATH_MAX-1);
                     user_datapath[PATH_MAX-1] = '\0';
-                    if (strlen(user_datapath) > 0) {
+                    if ((strlen(user_datapath) > 0) && (access(user_datapath, R_OK|W_OK)) == 0) {
                         user_defined_datapath = 1;
                         debug("Using \"%s\" as data path\n");
                     }
@@ -113,7 +114,7 @@ int parse_argv(int argc, char const *argv[]) {
                     i += 1;
                     strncpy(user_datapath, argv[i], PATH_MAX-1);
                     user_datapath[PATH_MAX-1] = '\0';
-                    if (strlen(user_datapath) > 0) {
+                    if ((strlen(user_datapath) > 0) && (access(user_datapath, R_OK|W_OK)) == 0) {
                         user_defined_datapath = 1;
                         debug("Using \"%s\" as data path\n");
                     }

--- a/cocoa/main.m
+++ b/cocoa/main.m
@@ -108,7 +108,7 @@ int parse_argv(int argc, char const *argv[]) {
                     user_datapath[PATH_MAX-1] = '\0';
                     if ((strlen(user_datapath) > 0) && (access(user_datapath, R_OK|W_OK)) == 0) {
                         user_defined_datapath = 1;
-                        debug("Using \"%s\" as data path\n");
+                        debug("Using \"%s\" as data path\n", user_datapath);
                     }
                 } else if((strlen(argv[i]) == 10) && (argc > i+1)) {
                     i += 1;
@@ -116,10 +116,11 @@ int parse_argv(int argc, char const *argv[]) {
                     user_datapath[PATH_MAX-1] = '\0';
                     if ((strlen(user_datapath) > 0) && (access(user_datapath, R_OK|W_OK)) == 0) {
                         user_defined_datapath = 1;
-                        debug("Using \"%s\" as data path\n");
+                        debug("Using \"%s\" as data path\n", user_datapath);
                     }
                 } else {
-                    debug("Ignoring \"--datapath\" argument\n");
+                    debug("Error processing \"--datapath\" argument\n");
+                    exit(6);
                 }
             }
             if(!strcmp(argv[i], "--theme")) {

--- a/cocoa/main.m
+++ b/cocoa/main.m
@@ -246,16 +246,15 @@ void ensure_directory_r(char *path, int perm) {
 
 /* it occured to me that we should probably make datapath allocate memory for its caller */
 int datapath(uint8_t *dest) {
-    if (utox_portable) {
-        const char *home = [NSBundle.mainBundle.bundlePath stringByDeletingLastPathComponent].UTF8String;
-        int l = sprintf((char*)dest, "%.238s/tox", home);
-        ensure_directory_r((char*)dest, 0700);
+    if (user_defined_datapath) {
+        int l = sprintf((char*)dest, "%.230s", user_datapath);
         dest[l++] = '/';
 
         return l;
-    } else if (user_defined_datapath) {
-        int l = sprintf((char*)dest, "%.230s", user_datapath);
-        mkdir((char*)dest, 0700);
+    } else if (utox_portable) {
+        const char *home = [NSBundle.mainBundle.bundlePath stringByDeletingLastPathComponent].UTF8String;
+        int l = sprintf((char*)dest, "%.238s/tox", home);
+        ensure_directory_r((char*)dest, 0700);
         dest[l++] = '/';
 
         return l;

--- a/utox.1
+++ b/utox.1
@@ -25,7 +25,7 @@ Choose a color scheme. Possible options are \fIdefault\fP, \fIdark\fP,
 
 .IP "\fB\-\-datapath=\fP<DIR>"
 Like portable mode, but let you choose a different location for
-stored files.
+stored files. The directory structure must already exists.
 
 IGNORED WHEN "\-\-portable" IS USED
 

--- a/utox.1
+++ b/utox.1
@@ -3,7 +3,7 @@
 µTox \- Lightweight Tox client
 
 .SH SYNOPSIS
-usage: utox [--portable] [--theme <default|dark|light|highcontrast>]
+usage: utox [--portable] [--datapath=<DIR>] [--theme <default|dark|light|highcontrast>]
    or: utox --version
 
 .SH DESCRIPTION
@@ -22,6 +22,12 @@ usage: utox [--portable] [--theme <default|dark|light|highcontrast>]
 .IP "\fB\-\-theme\fP <THEME>"
 Choose a color scheme. Possible options are \fIdefault\fP, \fIdark\fP,
 \fIlight\fP, or \fIhighcontrast\fP, or \fPzenburn\fP.
+
+.IP "\fB\-\-datapath=\fP<DIR>"
+Like portable mode, but let you choose a different location for
+stored files.
+
+IGNORED WHEN "\-\-portable" IS USED
 
 .IP \fB\-\-portable\fP
 Run in portable mode.

--- a/utox.1
+++ b/utox.1
@@ -27,10 +27,10 @@ Choose a color scheme. Possible options are \fIdefault\fP, \fIdark\fP,
 Like portable mode, but let you choose a different location for
 stored files. The directory structure must already exists.
 
-IGNORED WHEN "\-\-portable" IS USED
-
 .IP \fB\-\-portable\fP
 Run in portable mode.
+
+IGNORED WHEN "\-\-datapath" IS USED
 
 .IP \fB\-\-version\fP
 Print version and exit.

--- a/utox.1
+++ b/utox.1
@@ -23,7 +23,7 @@ usage: utox [--portable] [--datapath=<DIR>] [--theme <default|dark|light|highcon
 Choose a color scheme. Possible options are \fIdefault\fP, \fIdark\fP,
 \fIlight\fP, or \fIhighcontrast\fP, or \fPzenburn\fP.
 
-.IP "\fB\-\-datapath=\fP<DIR>"
+.IP "\fB\-\-datapath\fP <DIR>"
 Like portable mode, but let you choose a different location for
 stored files. The directory structure must already exists.
 

--- a/windows/main.c
+++ b/windows/main.c
@@ -1221,7 +1221,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR cmd, int n
                     user_datapath[MAX_PATH-1] = '\0';
                     if ((strlen(user_datapath) > 0) && (_access_s(user_datapath, 6) == 0)) {
                         user_defined_datapath = 1;
-                        debug("Using \"%s\" as data path\n");
+                        debug("Using \"%s\" as data path\n", user_datapath);
                     }
                 } else if((strlen(arglist[i]) == 10) && (argc > i+1)) {
                     ++i;
@@ -1231,10 +1231,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR cmd, int n
                     user_datapath[MAX_PATH-1] = '\0';
                     if ((strlen(user_datapath) > 0) && (_access_s(user_datapath, 6) == 0)) {
                         user_defined_datapath = 1;
-                        debug("Using \"%s\" as data path\n");
+                        debug("Using \"%s\" as data path\n", user_datapath);
                     }
                 } else {
-                    debug("Ignoring \"--datapath\" argument\n");
+                    debug("Error processing \"--datapath\" argument\n");
+                    return 6;
                 }
             } else if(wcscmp(arglist[i], L"--theme") == 0){
                 debug("Searching for theme from argv\n");

--- a/windows/main.c
+++ b/windows/main.c
@@ -838,17 +838,16 @@ int datapath_old(uint8_t *dest)
 
 int datapath(uint8_t *dest)
 {
-    if (utox_portable) {
+    if (user_defined_datapath) {
+        uint8_t *p = dest + strlen((char*)dest);
+	*p++ = '\\';
+        return p - dest;
+    } else if (utox_portable) {
         uint8_t *p = dest;
         strcpy((char *)p, utox_portable_save_path); p += strlen(utox_portable_save_path);
         strcpy((char *)p, "\\Tox"); p += 4;
         CreateDirectory((char*)dest, NULL);
         *p++ = '\\';
-        return p - dest;
-    } else if (user_defined_datapath) {
-        uint8_t *p = dest + strlen((char*)dest);
-        CreateDirectory((char*)dest, NULL);
-	*p++ = '\\';
         return p - dest;
     } else {
         if(SUCCEEDED(SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, 0, (char*)dest))) {

--- a/windows/main.c
+++ b/windows/main.c
@@ -839,7 +839,8 @@ int datapath_old(uint8_t *dest)
 int datapath(uint8_t *dest)
 {
     if (user_defined_datapath) {
-        uint8_t *p = dest + strlen((char*)dest);
+        uint8_t *p = dest;
+       	strcpy((char *)p, user_datapath); p += strlen(user_datapath);
 	*p++ = '\\';
         return p - dest;
     } else if (utox_portable) {

--- a/windows/main.c
+++ b/windows/main.c
@@ -1,5 +1,6 @@
 #include <windows.h>
 #include <windowsx.h>
+#include <io.h>
 
 #include "audio.c"
 
@@ -1218,7 +1219,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR cmd, int n
 		    wcstombs(clean_arg, arglist[i], strlen(arglist[i]));
                     strncpy(user_datapath, clean_arg+11, MAX_PATH-1);
                     user_datapath[MAX_PATH-1] = '\0';
-                    if (strlen(user_datapath) > 0) {
+                    if ((strlen(user_datapath) > 0) && (_access_s(user_datapath, 6) == 0)) {
                         user_defined_datapath = 1;
                         debug("Using \"%s\" as data path\n");
                     }
@@ -1228,7 +1229,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR cmd, int n
 		    wcstombs(clean_arg, arglist[i], strlen(arglist[i]));
                     strncpy(user_datapath, clean_arg, MAX_PATH-1);
                     user_datapath[MAX_PATH-1] = '\0';
-                    if (strlen(user_datapath) > 0) {
+                    if ((strlen(user_datapath) > 0) && (_access_s(user_datapath, 6) == 0)) {
                         user_defined_datapath = 1;
                         debug("Using \"%s\" as data path\n");
                     }

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -1057,7 +1057,8 @@ int main(int argc, char *argv[])
                         debug("Using \"%s\" as data path\n");
                     }
                 } else if((strlen(argv[i]) == 10) && (argc > i+1)) {
-                    strncpy(user_datapath, argv[i+1], PATH_MAX-1);
+                    ++i;
+                    strncpy(user_datapath, argv[i], PATH_MAX-1);
                     user_datapath[PATH_MAX-1] = '\0';
                     if (strlen(user_datapath) > 0) {
                         user_defined_datapath = 1;

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -1053,7 +1053,7 @@ int main(int argc, char *argv[])
                     user_datapath[PATH_MAX-1] = '\0';
                     if ((strlen(user_datapath) > 0) && (access(user_datapath, R_OK|W_OK)) == 0) {
                         user_defined_datapath = 1;
-                        debug("Using \"%s\" as data path\n");
+                        debug("Using \"%s\" as data path\n", user_datapath);
                     }
                 } else if((strlen(argv[i]) == 10) && (argc > i+1)) {
                     ++i;
@@ -1061,10 +1061,11 @@ int main(int argc, char *argv[])
                     user_datapath[PATH_MAX-1] = '\0';
                     if ((strlen(user_datapath) > 0) && (access(user_datapath, R_OK|W_OK)) == 0) {
                         user_defined_datapath = 1;
-                        debug("Using \"%s\" as data path\n");
+                        debug("Using \"%s\" as data path\n", user_datapath);
                     }
                 } else {
-                    debug("Ignoring \"--datapath\" argument\n");
+                    debug("Error processing \"--datapath\" argument\n");
+                    return 6;
                 }
             } else if(!strcmp(argv[i], "--theme")) {
                 parse_args_wait_for_theme = 1;

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -1048,9 +1048,16 @@ int main(int argc, char *argv[])
                 debug("Launching uTox in portable mode: All data will be saved to the tox folder in the current working directory\n");
                 utox_portable = 1;
             } else if(strncmp(argv[i], "--datapath", 10) == 0) {
-                if(strncmp(argv[i]+10, "=", 1) == 0) {
-                    user_datapath[0] = '\0';
+                user_datapath[0] = '\0';
+                if ((strlen(argv[i]) > 10) && (argv[i][10] == '=')) {
                     strncpy(user_datapath, argv[i]+11, PATH_MAX-1);
+                    user_datapath[PATH_MAX-1] = '\0';
+                    if (strlen(user_datapath) > 0) {
+                        user_defined_datapath = 1;
+                        debug("Using \"%s\" as data path\n");
+                    }
+                } else if((strlen(argv[i]) == 10) && (argc > i+1)) {
+                    strncpy(user_datapath, argv[i+1], PATH_MAX-1);
                     user_datapath[PATH_MAX-1] = '\0';
                     if (strlen(user_datapath) > 0) {
                         user_defined_datapath = 1;

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -791,14 +791,13 @@ int datapath_old(uint8_t *dest)
 
 int datapath(uint8_t *dest)
 {
-    if (utox_portable) {
-        int l = sprintf((char*)dest, "./tox");
-        mkdir((char*)dest, 0700);
+    if (user_defined_datapath) {
+        int l = sprintf((char*)dest, "%.230s", user_datapath);
         dest[l++] = '/';
 
         return l;
-    } else if (user_defined_datapath) {
-        int l = sprintf((char*)dest, "%.230s", user_datapath);
+    } else if (utox_portable) {
+        int l = sprintf((char*)dest, "./tox");
         mkdir((char*)dest, 0700);
         dest[l++] = '/';
 

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -1052,7 +1052,7 @@ int main(int argc, char *argv[])
                 if ((strlen(argv[i]) > 10) && (argv[i][10] == '=')) {
                     strncpy(user_datapath, argv[i]+11, PATH_MAX-1);
                     user_datapath[PATH_MAX-1] = '\0';
-                    if (strlen(user_datapath) > 0) {
+                    if ((strlen(user_datapath) > 0) && (access(user_datapath, R_OK|W_OK)) == 0) {
                         user_defined_datapath = 1;
                         debug("Using \"%s\" as data path\n");
                     }
@@ -1060,7 +1060,7 @@ int main(int argc, char *argv[])
                     ++i;
                     strncpy(user_datapath, argv[i], PATH_MAX-1);
                     user_datapath[PATH_MAX-1] = '\0';
-                    if (strlen(user_datapath) > 0) {
+                    if ((strlen(user_datapath) > 0) && (access(user_datapath, R_OK|W_OK)) == 0) {
                         user_defined_datapath = 1;
                         debug("Using \"%s\" as data path\n");
                     }

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -792,7 +792,7 @@ int datapath_old(uint8_t *dest)
 int datapath(uint8_t *dest)
 {
     if (user_defined_datapath) {
-        int l = sprintf((char*)dest, "%.230s", user_datapath);
+        int l = sprintf((char*)dest, "%s", user_datapath);
         dest[l++] = '/';
 
         return l;

--- a/xlib/main.c
+++ b/xlib/main.c
@@ -168,25 +168,6 @@ static void setclipboard(void)
     return first;
 }*/
 
-/* Simulate mkdir -p */
-static void mkpath(const char *path, mode_t mode) {
-    char tmp[256];
-    char *p = NULL;
-    size_t len;
-
-    snprintf(tmp, sizeof(tmp), "%s", path);
-    len = strlen(tmp);
-    if (tmp[len - 1] == '/')
-        tmp[len - 1] = 0;
-    for (p = tmp + 1; *p; p++)
-         if (*p == '/') {
-             *p = 0;
-             mkdir(tmp, mode);
-             *p = '/';
-         }
-    mkdir(tmp, mode);
-}
-
 void postmessage(uint32_t msg, uint16_t param1, uint16_t param2, void *data)
 {
     XEvent event = {
@@ -812,20 +793,20 @@ int datapath(uint8_t *dest)
 {
     if (utox_portable) {
         int l = sprintf((char*)dest, "./tox");
-        mkpath((char*)dest, 0700);
+        mkdir((char*)dest, 0700);
         dest[l++] = '/';
 
         return l;
     } else if (user_defined_datapath) {
         int l = sprintf((char*)dest, "%.230s", user_datapath);
-        mkpath((char*)dest, 0700);
+        mkdir((char*)dest, 0700);
         dest[l++] = '/';
 
         return l;
     } else {
         char *home = getenv("HOME");
         int l = sprintf((char*)dest, "%.230s/.config/tox", home);
-        mkpath((char*)dest, 0700);
+        mkdir((char*)dest, 0700);
         dest[l++] = '/';
 
         return l;
@@ -836,7 +817,7 @@ int datapath_subdir(uint8_t *dest, const char *subdir)
 {
     int l = datapath(dest);
     l += sprintf((char*)(dest+l), "%s", subdir);
-    mkpath((char*)dest, 0700);
+    mkdir((char*)dest, 0700);
     dest[l++] = '/';
 
     return l;


### PR DESCRIPTION
-- @grayhatter edits

- [x] Windows support
- [x] OSX support
- [x] Ignore `--portable`
- [x] Error checking
    - [x] Exit on error
    - [x] Warn on long path lengths
    - [x] It shouldn't create the directory for the user, it should just fail when the directory doesn't exist. Or when the user lack the necessary permissions to interact with the file/directory
- [x] Rebase or merge (after these are fixed)