### PR TITLE
Fix Makefile var expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ install: utox
 
 	mkdir -p $(DESTDIR)$(PREFIX)/share/applications
 	install -m 644 utox.desktop $(DESTDIR)$(PREFIX)/share/applications/utox.desktop
-	if [ "$UNITY" -eq "1" ]; then echo "X-MessagingMenu-UsesChatSection=true" >> $(DESTDIR)$(PREFIX)/share/applications/utox.desktop; fi
+	if [ "$(UNITY)" -eq "1" ]; then echo "X-MessagingMenu-UsesChatSection=true" >> $(DESTDIR)$(PREFIX)/share/applications/utox.desktop; fi
 
 	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
 	install -m 644 utox.1 $(DESTDIR)$(PREFIX)/share/man/man1/utox.1


### PR DESCRIPTION
Fixes this:
```
if [ "NITY" -eq "1" ]; then echo "X-MessagingMenu-UsesChatSection=true" >> /var/tmp/portage/net-im/utox-9999/image//usr/share/applications/utox.desktop; fi
/bin/sh: 0 行: [: NITY: 整数の式が予期されます
```