### PR TITLE
do not block video device when video is not used

### DIFF
--- a/tox.h
+++ b/tox.h
@@ -73,11 +73,17 @@ enum
 
 enum
 {
+    // kill the video thread
     VIDEO_KILL,
+    // set a new video device
     VIDEO_SET,
+    // start a video preview
     VIDEO_PREVIEW_START,
+    // end a video preview
     VIDEO_PREVIEW_END,
+    // start a video call
     VIDEO_CALL_START,
+    // end a video call
     VIDEO_CALL_END,
 };
 

--- a/ui_buttons.h
+++ b/ui_buttons.h
@@ -91,6 +91,8 @@ static void button_videopreview_onpress(void)
         video_begin(0, s->str, s->length, video_width, video_height);
         toxvideo_postmessage(VIDEO_PREVIEW_START, 0, 0, NULL);
         video_preview = 1;
+    } else {
+        debug("unable to start video preview. No info about frame size.\n");
     }
 }
 


### PR DESCRIPTION
initially open a device when it is selected but close it afterwards to
allow other programs to used it.
A device is now only opened if it is actually needed, meaning either a
preview window is opened or a call is started.

fixes #628

this is my first contribution here so please tell me if there is anything to adjust. I'm also not _that_ familiar with C. Any suggestions welcome.
