### PR TITLE
Renamed tab USER_INTERFACE for Italian localization

### DIFF
--- a/langs/it.h
+++ b/langs/it.h
@@ -146,7 +146,7 @@ msgid(UI)
 msgstr("UI")
 
 msgid(USER_INTERFACE)
-msgstr("Interfaccia Utente")
+msgstr("Interfaccia")
 
 msgid(UTOX_SETTINGS)
 msgstr("Impostazioni uTox")


### PR DESCRIPTION
Fix for https://github.com/notsecure/uTox/issues/1106