### PR TITLE
Set video window style mask to resizable on OS X.

### DIFF
--- a/cocoa/video.m
+++ b/cocoa/video.m
@@ -364,7 +364,7 @@ void* video_detect(void) {
 
 + (NSWindow *)createWindow {
 #define START_RECT (CGRect){0, 0, 100, 100}
-    NSWindow *ret = [[uToxIroncladWindow alloc] initWithContentRect:START_RECT styleMask:NSHUDWindowMask | NSUtilityWindowMask | NSClosableWindowMask | NSTitledWindowMask backing:NSBackingStoreBuffered defer:YES];
+    NSWindow *ret = [[uToxIroncladWindow alloc] initWithContentRect:START_RECT styleMask:NSHUDWindowMask | NSUtilityWindowMask | NSClosableWindowMask | NSTitledWindowMask | NSResizableWindowMask backing:NSBackingStoreBuffered defer:YES];
     ret.hidesOnDeactivate = NO;
     uToxIroncladView *iv = [[self alloc] initWithFrame:ret.frame];
     ret.contentView = iv;


### PR DESCRIPTION
I believe the style mask lacking the resizable option was in error so I'm submitting a pull request to correct it.
