### PR TITLE
make audio & video init sequential

### DIFF
--- a/tox.c
+++ b/tox.c
@@ -668,8 +668,11 @@ void tox_thread(void *UNUSED(args))
 
         // Start the treads
         thread(audio_thread, av);
+        while(!audio_thread_init) yieldcpu(1);
         thread(video_thread, av);
+        while(!video_thread_init) yieldcpu(1);
         thread(toxav_thread, av);
+        while(!toxav_thread_init) yieldcpu(1);
 
         //
         _Bool connected = 0;


### PR DESCRIPTION
In OS X 10.9.5 I don't see the audio input devices at every ~second program start.
I think it is related to threading. The serialisation of the audio & video init fixes it.