### PR TITLE
confirm delivery of text messages

### DIFF
--- a/tox.c
+++ b/tox.c
@@ -902,7 +902,6 @@ static void tox_thread_message(Tox *tox, ToxAv *av, uint64_t time, uint8_t msg, 
     
 	 case TOX_FRIEND_RECEIPT: {
 	 
-	 		debug ("TOX_FRIEND_RECEIPT\n");
 	 		not_acked_message_receipt_cb(param1, param2);
 	 		break;
 	 }
@@ -1286,7 +1285,6 @@ void tox_message(uint8_t tox_message_id, uint16_t param1, uint16_t param2, void 
     
 	case FRIEND_RECEIPT: {
 	
-		debug ("tox_message FRIEND_RECEITP\n");
 		tox_postmessage (TOX_FRIEND_RECEIPT, param1, param2, 0);
 		break;
 	
@@ -1963,6 +1961,7 @@ for (c=0; c<n_not_acked_messages; c++) {
 	if (not_acked_messages[c]->time != 0) {
 		not_acked_messages_swp[c2] = not_acked_messages[c];
 		c2 += 1;	}
+	if (not_acked_messages[c]->time == 0) free (not_acked_messages[c]);
 		}
 		
 n_not_acked_messages = c2;

--- a/tox.h
+++ b/tox.h
@@ -47,6 +47,7 @@ enum {
     TOX_FILE_OUTGOING_PAUSE,
     TOX_FILE_OUTGOING_CANCEL,
     TOX_FRIEND_ONLINE,
+    TOX_FRIEND_RECEIPT,
 };
 
 struct TOX_SEND_INLINE_MSG {
@@ -118,6 +119,8 @@ enum {
     FRIEND_STATUS,
     FRIEND_TYPING,
     FRIEND_ONLINE,
+    FRIEND_RECEIPT,
+
 
     /* friend a/v */
     FRIEND_CALL_STATUS,
@@ -184,3 +187,27 @@ void toxav_postmessage(uint8_t msg, uint32_t param1, uint32_t param2, void *data
 void tox_message(uint8_t msg, uint16_t param1, uint16_t param2, void *data);
 
 void tox_settingschanged(void);
+
+//-----------------------------------------------
+
+
+typedef struct not_acked_message_t {
+
+	uint32_t msg_id;
+	uint32_t friend_id;
+	uint32_t time;
+	
+}  not_acked_message_t;
+
+#define MAX_PENDING_MESSAGES 64
+#define MSG_RECEIPT_TIMEOUT 1000 //miliseconds
+
+not_acked_message_t** not_acked_messages;
+not_acked_message_t** not_acked_messages_swp;
+
+uint32_t n_not_acked_messages;
+
+void add_not_acked_message (uint32_t fid, uint32_t mid);
+void not_acked_message_receipt_cb (uint32_t fid, uint32_t mid);
+void not_acked_messages_timer();
+

--- a/tox_callbacks.h
+++ b/tox_callbacks.h
@@ -112,11 +112,13 @@ static void callback_typing_change(Tox *UNUSED(tox), uint32_t fid, _Bool is_typi
     debug("Friend Typing (%u): %u\n", fid, is_typing);
 }
 
-static void callback_read_receipt(Tox *UNUSED(tox), uint32_t fid, uint32_t receipt, void *UNUSED(userdata))
+static void callback_read_receipt(Tox* tox, uint32_t fid, uint32_t receipt, void *UNUSED(userdata))
 {
-    //postmessage(FRIEND_RECEIPT, fid, receipt);
+   // postmessage(FRIEND_RECEIPT, fid, receipt, NULL);
+   
+   tox_message (FRIEND_RECEIPT, fid, receipt, 0);
 
-    debug("Friend Receipt (%u): %u\n", fid, receipt);
+    debug("Friend Receipt (%u): %u \n", fid, receipt);
 }
 
 static void callback_connection_status(Tox *tox, uint32_t fid, TOX_CONNECTION status, void *UNUSED(userdata)){


### PR DESCRIPTION
Sent messages are added to a list. The list is checked periodically to see if sent messages get a receipt. If a message goes unacknowledged for more than MSG_RECEIPT_TIMEOUT miliseconds, the user gets a notice in the chat window.